### PR TITLE
Temporary disable custom jobs

### DIFF
--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -1,27 +1,5 @@
 ---
 # zuul.d/layout.yaml
-- job:
-    name: molecule-tox-devel-centos-8
-    parent: molecule-tox-py36
-    vars:
-      tox_envlist: devel
-    attempts: 1
-
-- job:
-    name: molecule-tox-py27-centos-7
-    parent: molecule-tox-py27
-    attempts: 1
-
-- job:
-    name: molecule-tox-py36-centos-8
-    parent: molecule-tox-py36
-    attempts: 1
-
-- job:
-    name: molecule-tox-py37-fedora-30
-    parent: molecule-tox-py37
-    attempts: 1
-
 - project:
     templates:
       - publish-to-pypi
@@ -30,18 +8,18 @@
         - molecule-tox-linters:
             vars:
               tox_envlist: lint
-        - molecule-tox-packaging:
-            vars:
-              tox_envlist: packaging
-        - molecule-tox-py27-centos-7:
-            # broken vagrant-libvirt install
-            voting: false
-        - molecule-tox-py36-centos-8:
-            # broken vagrant-libvirt install
-            voting: false
-        - molecule-tox-py37-fedora-30
-        - molecule-tox-devel-centos-8:
-            # broken vagrant-libvirt install
-            voting: false
+    # - molecule-tox-packaging:
+    #     vars:
+    #       tox_envlist: packaging
+    # - molecule-tox-py27-centos-7:
+    #     # broken vagrant-libvirt install
+    #     voting: false
+    # - molecule-tox-py36-centos-8:
+    #     # broken vagrant-libvirt install
+    #     voting: false
+    # - molecule-tox-py37-fedora-30
+    # - molecule-tox-devel-centos-8:
+    #     # broken vagrant-libvirt install
+    #     voting: false
     gate:
       jobs: *defaults


### PR DESCRIPTION
Allows us to move custom jobs to molecule projects.