### PR TITLE
allowing merge_dict calls to correctly update the main dict

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -560,12 +560,16 @@ class VagrantClient(object):
             },
         }
 
-        molecule.util.merge_dicts(
-            d["config"]["options"], self._module.params["config_options"]
+        d["config"]["options"].update(
+            molecule.util.merge_dicts(
+                d["config"]["options"], self._module.params["config_options"]
+            )
         )
 
-        molecule.util.merge_dicts(
-            d["provider"]["options"], self._module.params["provider_options"]
+        d["provider"]["options"].update(
+            molecule.util.merge_dicts(
+                d["provider"]["options"], self._module.params["provider_options"]
+            )
         )
 
         return d


### PR DESCRIPTION
This fixes a bug where the params for `config_options` and `provider_options` were not being merged in the `_get_vagrant_config_dict` function

Manually tested this with my remote Libvirt setup.