### PR TITLE
zuul.d/layout.yaml: Remove python 2.7 centos 7 tests

### DIFF
--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -11,9 +11,6 @@
         - molecule-tox-packaging:
             vars:
               tox_envlist: packaging
-        - molecule-tox-py27-centos-7:
-            # broken vagrant-libvirt install
-            voting: false
         - molecule-tox-py36-centos-8:
             # broken vagrant-libvirt install
             voting: false


### PR DESCRIPTION
Since molecule commit "Make py36 minimal version needed for running molecule"
(cd223688e14b2), python 2.7 and centos 7 are not supported anymore by molecule.
So, kill testing for this platform.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>