### PR TITLE
Fix vagrant working directory

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -518,9 +518,11 @@ class VagrantClient(object):
         self._write_vagrantfile()
 
     def _get_vagrant(self):
-        env = os.environ.copy()
-        env["VAGRANT_CWD"] = os.environ["MOLECULE_EPHEMERAL_DIRECTORY"]
-        v = vagrant.Vagrant(out_cm=self.stdout_cm, err_cm=self.stderr_cm, env=env)
+        v = vagrant.Vagrant(
+            out_cm=self.stdout_cm,
+            err_cm=self.stderr_cm,
+            root=os.environ["MOLECULE_EPHEMERAL_DIRECTORY"],
+        )
 
         return v
 

--- a/molecule_vagrant/test/functional/test_func.py
+++ b/molecule_vagrant/test/functional/test_func.py
@@ -23,10 +23,9 @@ import pytest
 import os
 import sh
 
+from molecule import util
 from molecule import logger
 from molecule.test.conftest import run_command, change_dir_to
-
-# import change_dir_to, temp_dir
 
 LOG = logger.get_logger(__name__)
 
@@ -48,4 +47,17 @@ def test_command_init_scenario(temp_dir):
         assert os.path.isdir(scenario_directory)
 
         cmd = sh.molecule.bake("--debug", "test", "-s", "test-scenario")
+        run_command(cmd)
+
+
+@pytest.mark.parametrize("scenario", [("vagrant_root")])
+def test_vagrant_root(temp_dir, scenario):
+    options = {"scenario_name": scenario}
+
+    scenario_directory = os.path.join(
+        os.path.dirname(util.abs_path(__file__)), os.path.pardir, "scenarios"
+    )
+
+    with change_dir_to(scenario_directory):
+        cmd = sh.molecule.bake("test", **options)
         run_command(cmd)

--- a/molecule_vagrant/test/scenarios/molecule/vagrant_root/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/vagrant_root/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: sample task  # noqa 305
+      shell:
+        cmd: uname
+        warn: false
+      changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/vagrant_root/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/vagrant_root/molecule.yml
@@ -1,0 +1,19 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+lint:
+  /bin/true
+platforms:
+  - name: instance
+    box: centos/7
+    provision: true
+    instance_raw_config_args:
+      - "vm.provision :shell, inline: \"echo #{Dir.pwd} > /tmp/workdir\""
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/vagrant_root/verify.yml
+++ b/molecule_vagrant/test/scenarios/molecule/vagrant_root/verify.yml
@@ -1,0 +1,30 @@
+---
+- hosts: all
+  tasks:
+    - name: Look for /tmp/workdir
+      stat:
+        path: /tmp/workdir
+      register: workdir
+
+    - name: Make sure there's a /vagrant
+      assert:
+        that:
+          - workdir.stat.exists | bool
+
+    - name: Get /tmp/workdir file content
+      command: cat /tmp/workdir
+      changed_when: false
+      register: workdir_content
+
+    - name: print molecule ephemeral directory
+      debug:
+        msg: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+
+    - name: print workdir file content
+      debug:
+        var: workdir_content.stdout
+
+    - name: Check /tmp/workdir content
+      assert:
+        that:
+          - "workdir_content.stdout == lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY')"


### PR DESCRIPTION
vagrant does a lot of thing according to its working directory, like
reading the Vagrantfile, launching external commands, etc...
Since vagrant is started by python-vagrant, itself started by ansible
in the directory containing the create/destroy/... test playbooks, it means
that the current directory is something like $PYTHONDIR/molecule_vagrant/playbooks/
and not the molecule ephemeral directory.

In order to make sure that vagrant finds its files, the code is using
VAGRANT_CWD environment variable, which allows vagrant to work but it
doesn't change the current directory. For libvirt, it's not a problem but
for virtualbox, it will create files in this current directory. Writing
to this directory may even be forbidden.

Change the code to set the 'root' parameter of the vagrant class,
which will chdir() to the molecule ephemeral directory.

For the test case, the idea was to find a way to get vagrant current
directory. The Vagrantfile is a ruby file parsed and interpreted by
vagrant, so at that time, the current directory is the one of vagrant.
This value computed with 'Dir.pwd' in the Vagrantfile, is stored in a
file inside the instance with the shell provisioner and the ansible
verifier checks that its content is the molecule ephemeral directory.

Fixes: #20
Signed-off-by: Arnaud Patard <apatard@hupstream.com>