### PR TITLE
Add tests for config_options and provider_options

### DIFF
--- a/molecule_vagrant/test/functional/test_func.py
+++ b/molecule_vagrant/test/functional/test_func.py
@@ -50,7 +50,9 @@ def test_command_init_scenario(temp_dir):
         run_command(cmd)
 
 
-@pytest.mark.parametrize("scenario", [("vagrant_root")])
+@pytest.mark.parametrize(
+    "scenario", [("vagrant_root"), ("config_options"), ("provider_config_options")]
+)
 def test_vagrant_root(temp_dir, scenario):
     options = {"scenario_name": scenario}
 

--- a/molecule_vagrant/test/scenarios/molecule/config_options/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_options/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: sample task  # noqa 305
+      shell:
+        cmd: uname
+        warn: false
+      changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
@@ -1,0 +1,18 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+lint:
+  /bin/true
+platforms:
+  - name: instance
+    config_options:
+      synced_folder: true
+    box: centos/7
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/config_options/verify.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_options/verify.yml
@@ -1,0 +1,14 @@
+---
+- hosts: all
+  tasks:
+    - name: Look for /vagrant
+      stat:
+        path: /vagrant
+      register: vagrantdir
+
+    - name: Make sure there's a /vagrant
+      assert:
+        that:
+          - vagrantdir.stat.exists | bool
+          - vagrantdir.stat.isdir is defined
+          - vagrantdir.stat.isdir | bool

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: sample task  # noqa 305
+      shell:
+        cmd: uname
+        warn: false
+      changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
@@ -1,0 +1,18 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+lint:
+  /bin/true
+platforms:
+  - name: instance
+    provider_options:
+      nic_model_type: '"rtl8139"'
+    box: centos/7
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/verify.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/verify.yml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  gather_facts: true
+  tasks:
+  - name: Set interface dict name
+    set_fact:
+      iface: "{{ ansible_default_ipv4.interface }}"
+
+  - name: Check network card pci infos
+    assert:
+      that:
+        - "ansible_facts[iface].module == '8139cp'"


### PR DESCRIPTION
This pull request depends on https://github.com/ansible-community/molecule-vagrant/pull/16 since it's the missing test cases for the two bugs fixed by it.

This means that:
- the test will fail now but will have to be triggered again once the other pull request is merged
- it should not be merged now (hopefully, the CI will prevent that)