### PR TITLE
Fix the vagrant provider name if no value is defined or empty value provided

### DIFF
--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -17,7 +17,7 @@
         platform_box_version: "{{ item.box_version | default(omit) }}"
         platform_box_url: "{{ item.box_url | default(omit) }}"
 
-        provider_name: "{{ molecule_yml.driver.provider.name }}"
+        provider_name: "{{ molecule_yml.driver.provider.name | default(omit, true) }}"
         provider_memory: "{{ item.memory | default(omit) }}"
         provider_cpus: "{{ item.cpus | default(omit) }}"
         provider_options: "{{ item.provider_options | default(omit) }}"

--- a/molecule_vagrant/playbooks/destroy.yml
+++ b/molecule_vagrant/playbooks/destroy.yml
@@ -9,7 +9,7 @@
       vagrant:
         instance_name: "{{ item.name }}"
         platform_box: "{{ item.box | default(omit) }}"
-        provider_name: "{{ molecule_yml.driver.provider.name }}"
+        provider_name: "{{ molecule_yml.driver.provider.name | default(omit, true) }}"
         provider_options: "{{ item.provider_options | default(omit) }}"
         provider_raw_config_args: "{{ item.provider_raw_config_args | default(omit) }}"
         force_stop: "{{ item.force_stop | default(true) }}"


### PR DESCRIPTION
Fix the vagrant provider name so that if no value is defined or empty value provided the default value for the driver is used.

For example the below doesn't work
```
...
driver:
  name: vagrant
platforms:
...
```

But the example the below does
```
...
driver:
  name: vagrant
  provider:
    name: virtualbox
platforms:
...
```