### PR TITLE
Fix destroying a machine if no box is provided in the config.

### DIFF
--- a/molecule_vagrant/playbooks/destroy.yml
+++ b/molecule_vagrant/playbooks/destroy.yml
@@ -8,7 +8,7 @@
     - name: Destroy molecule instance(s)
       vagrant:
         instance_name: "{{ item.name }}"
-        platform_box: "{{ item.box | default(omit) }}"
+        platform_box: "{{ item.box | default('generic/alpine310') }}"
         provider_name: "{{ molecule_yml.driver.provider.name }}"
         provider_options: "{{ item.provider_options | default(omit) }}"
         provider_raw_config_args: "{{ item.provider_raw_config_args | default(omit) }}"


### PR DESCRIPTION
If there is no value is supplied for the machine box it fails to be destroyed, change the destroy default value to the same default value that is in the create.yml so that it is destroyed when no value is provided.

For example the below doesn't work
```
...
platforms:
  - name: instance
provisioner:
...
```

The below works.

```
...
platforms:
  - name: instance
    box: "alpine310"
provisioner:
...
```