### PR TITLE
Refactor to support multiple instances + general improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,10 @@ Here's a full example with the libvirt provider:
        provider_raw_config_args:
          - "cpuset = '1-4,^3,6'"
 
+Note: v0.4 is backwards-incompatible with v0.3 and under, if you used those
+versions you will need to update your `molecule.yml` files (and any custom
+`create.yml` files).
+
 .. _`fedora/32-cloud-base`: https://app.vagrantup.com/fedora/boxes/32-cloud-base
 
 .. _get-involved:

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,7 @@ Here's a full example with the libvirt provider:
      provider:
        # Can be any supported provider, defaults to VirtualBox
        name: libvirt
+       parallel: yes
 
    platforms:
      - name: instance

--- a/README.rst
+++ b/README.rst
@@ -53,38 +53,37 @@ Here's a full example with the libvirt provider:
    driver:
      name: vagrant
      provider:
-       # Can be any supported provider (VBox, Parallels, libvirt, etc)
+       # Can be any supported provider, defaults to VirtualBox
        name: libvirt
 
    platforms:
      - name: instance
        # List of dictionaries mapped to `config.vm.network`
-       interfaces:
-         # `network_name` is the required identifier, all other keys map to
-         # arguments.
-         - network_name: forwarded_port
-           guest: 80
-           host: 8080
-       # List of raw Vagrant `config` options
-       instance_raw_config_args:
-         - 'vagrant.plugins = ["vagrant-libvirt"]'
-       # Dictionary of `config` options. Note that string values need to be
-       # explicitly enclosed in quotes.
-       config_options:
-         ssh.keep_alive: yes
-         ssh.remote_user: "'vagrant'"
+       networks:
+         - identifier: forwarded_port
+           options:
+             guest: 80
+             host: 8080
+       # Which box to use, defaults to generic/alpine310
        box: fedora/32-cloud-base
        box_version: 32.20200422.0
        box_url:
        memory: 512
        cpus: 1
+       synced_folder: no
+       # Dictionary of `config` options
+       config_options:
+         ssh.keep_alive: yes
+         ssh.remote_user: vagrant
        # Dictionary of options passed to the provider
        provider_options:
-         video_type: "'vga'"
+         video_type: vga
+       # List of raw Vagrant `config` options
+       instance_raw_config_args:
+         - 'vagrant.plugins = ["vagrant-libvirt"]'
        # List of raw provider options
        provider_raw_config_args:
          - "cpuset = '1-4,^3,6'"
-       provision: no
 
 .. _`fedora/32-cloud-base`: https://app.vagrantup.com/fedora/boxes/32-cloud-base
 

--- a/molecule_vagrant/driver.py
+++ b/molecule_vagrant/driver.py
@@ -48,7 +48,7 @@ class Vagrant(Driver):
         inventory on the next execution of `molecule.command.create`, which
         happens to be the ``converge`` playbook.
 
-        This is an area needing improvement.  Gluing togher Ansible playbook
+        This is an area needing improvement.  Gluing together Ansible playbook
         return data and molecule is clunky.  Moving the playbook execution
         from ``sh`` to python is less than ideal, since the playbook's return
         data needs handled by an internal callback plugin.
@@ -214,7 +214,7 @@ class Vagrant(Driver):
         pass
 
     def template_dir(self):
-        """ Return path to its own cookiecutterm templates. It is used by init
+        """ Return path to its own cookiecutter templates. It is used by init
         command in order to figure out where to load the templates from.
         """
         return os.path.join(os.path.dirname(__file__), "cookiecutter")

--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -438,6 +438,12 @@ class VagrantClient(object):
             changed = True
             provision = self._module.params["provision"]
             try:
+                if not self._module.params["parallel"]:
+                    vagrant_env = os.environ.copy()
+                    vagrant_env["VAGRANT_NO_PARALLEL"] = "1"
+
+                    self._vagrant.env = vagrant_env
+
                 self._vagrant.up(provision=provision)
             except Exception:
                 # NOTE(retr0h): Ignore the exception since python-vagrant
@@ -605,6 +611,7 @@ def main():
             provider_options=dict(type="dict", default={}),
             provider_override_args=dict(type="list", default=None),
             provider_raw_config_args=dict(type="list", default=None),
+            parallel=dict(type="bool", default=True),
             provision=dict(type="bool", default=False),
             force_stop=dict(type="bool", default=False),
             state=dict(type="str", default="up", choices=["up", "destroy", "halt"]),

--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 #  Copyright (c) 2015-2018 Cisco Systems, Inc.
@@ -21,8 +21,6 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-
-from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
@@ -137,7 +135,7 @@ options:
     choices: ['up', 'halt', 'destroy']
     default: None
 requirements:
-    - python >= 2.6
+    - python >= 3
     - python-vagrant
     - vagrant
 """
@@ -380,7 +378,7 @@ stderr:
 """
 
 
-class VagrantClient(object):
+class VagrantClient:
     def __init__(self, module):
         self._module = module
 

--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -207,6 +207,12 @@ class VagrantClient:
         self._datetime = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.result = {}
 
+        # Disable parallelism if necessary
+        if not self._module.params["parallel"]:
+            vagrant_env = os.environ.copy()
+            vagrant_env["VAGRANT_NO_PARALLEL"] = "1"
+            self._vagrant.env = vagrant_env
+
     @contextlib.contextmanager
     def stdout_cm(self):
         """ Redirect the stdout to a log file. """
@@ -252,12 +258,6 @@ class VagrantClient:
         if not self._created():
             changed = True
             try:
-                if not self._module.params["parallel"]:
-                    vagrant_env = os.environ.copy()
-                    vagrant_env["VAGRANT_NO_PARALLEL"] = "1"
-
-                    self._vagrant.env = vagrant_env
-
                 self._vagrant.up(provider=self._module.params["provider"])
             except Exception:
                 # NOTE(retr0h): Ignore the exception since python-vagrant

--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -518,13 +518,11 @@ class VagrantClient(object):
         self._write_vagrantfile()
 
     def _get_vagrant(self):
-        v = vagrant.Vagrant(
+        return vagrant.Vagrant(
             out_cm=self.stdout_cm,
             err_cm=self.stderr_cm,
             root=os.environ["MOLECULE_EPHEMERAL_DIRECTORY"],
         )
-
-        return v
 
     def _get_vagrant_config_dict(self):
         d = {
@@ -614,16 +612,16 @@ def main():
         supports_check_mode=False,
     )
 
-    v = VagrantClient(module)
+    vagrant = VagrantClient(module)
 
     if module.params["state"] == "up":
-        v.up()
+        vagrant.up()
 
     if module.params["state"] == "destroy":
-        v.destroy()
+        vagrant.destroy()
 
     if module.params["state"] == "halt":
-        v.halt()
+        vagrant.halt()
 
     module.exit_json(**module.result)
 

--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -132,7 +132,7 @@ Vagrant.configure('2') do |config|
     {{ 'c.vm.box_url = "{}"'.format(instance.box_url) if instance.box_url }}
 
     c.vm.hostname = "{{ instance.name }}"
-    c.vm.synced_folder ".", "/vagrant", disabled: {{ ruby_format(not instance.synced_folder) }}
+    c.vm.synced_folder ".", "/vagrant", nfs_version: 3, disabled: {{ ruby_format(not instance.synced_folder) }}
 
     # Config options
     {% for key, value in instance.config_options.items() -%}

--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -340,8 +340,6 @@ class VagrantClient:
             root=os.environ["MOLECULE_EPHEMERAL_DIRECTORY"],
         )
 
-        return v
-
     def _get_vagrant_instances(self):
         return [
             {

--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -8,8 +8,8 @@
     - name: Create molecule instance(s)
       vagrant:
         instances: "{{ molecule_yml.platforms }}"
-        provider: "{{ molecule_yml.driver.provider.name | default('virtualbox') }}"
-        parallel: "{{ molecule_yml.driver.provider.parallel | default(True) }}"
+        provider: "{{ molecule_yml.driver.provider.name | default(omit) }}"
+        parallel: "{{ molecule_yml.driver.provider.parallel | default(omit) }}"
         state: up
       register: server
       no_log: false

--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -7,34 +7,13 @@
   tasks:
     - name: Create molecule instance(s)
       vagrant:
-        instance_name: "{{ item.name }}"
-        instance_interfaces: "{{ item.interfaces | default(omit) }}"
-        instance_raw_config_args: "{{ item.instance_raw_config_args | default(omit) }}"
-
-        config_options: "{{ item.config_options | default(omit) }}"
-
-        platform_box: "{{ item.box | default('generic/alpine310') }}"
-        platform_box_version: "{{ item.box_version | default(omit) }}"
-        platform_box_url: "{{ item.box_url | default(omit) }}"
-
-        provider_name: "{{ molecule_yml.driver.provider.name | default(omit, true) }}"
-        provider_memory: "{{ item.memory | default(omit) }}"
-        provider_cpus: "{{ item.cpus | default(omit) }}"
-        provider_options: "{{ item.provider_options | default(omit) }}"
-        provider_raw_config_args: "{{ item.provider_raw_config_args | default(omit) }}"
-        provider_override_args: "{{ item.provider_override_args | default(omit) }}"
-
-        provision: "{{ item.provision | default(omit) }}"
-        parallel: "{{ molecule_yml.driver.provider.parallel | default(yes) }}"
+        instances: "{{ molecule_yml.platforms }}"
+        provider: "{{ molecule_yml.driver.provider.name | default('virtualbox') }}"
+        parallel: "{{ molecule_yml.driver.provider.parallel | default(True) }}"
         state: up
       register: server
-      with_items: "{{ molecule_yml.platforms }}"
-      loop_control:
-        label: "{{ item.name }}"
       no_log: false
 
-    # NOTE(retr0h): Vagrant/VBox sucks and parallelizing instance creation
-    # causes issues.
     # Mandatory configuration for Molecule to function.
     - when: server.changed | bool
       block:

--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -25,7 +25,7 @@
         provider_override_args: "{{ item.provider_override_args | default(omit) }}"
 
         provision: "{{ item.provision | default(omit) }}"
-
+        parallel: "{{ molecule_yml.driver.provider.parallel | default(yes) }}"
         state: up
       register: server
       with_items: "{{ molecule_yml.platforms }}"

--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -35,12 +35,9 @@
 
     # NOTE(retr0h): Vagrant/VBox sucks and parallelizing instance creation
     # causes issues.
-
     # Mandatory configuration for Molecule to function.
-
     - when: server.changed | bool
       block:
-
         - name: Populate instance config dict
           set_fact:
             instance_conf_dict: {

--- a/molecule_vagrant/playbooks/destroy.yml
+++ b/molecule_vagrant/playbooks/destroy.yml
@@ -7,22 +7,14 @@
   tasks:
     - name: Destroy molecule instance(s)
       vagrant:
-        instance_name: "{{ item.name }}"
-        platform_box: "{{ item.box | default(omit) }}"
-        provider_name: "{{ molecule_yml.driver.provider.name | default(omit, true) }}"
-        provider_options: "{{ item.provider_options | default(omit) }}"
-        provider_raw_config_args: "{{ item.provider_raw_config_args | default(omit) }}"
-        force_stop: "{{ item.force_stop | default(true) }}"
-
+        instances: "{{ molecule_yml.platforms }}"
+        provider: "{{ molecule_yml.driver.provider.name | default('virtualbox') }}"
+        force_stop: "{{ item.force_stop | default(True) }}"
         state: destroy
       register: server
-      with_items: "{{ molecule_yml.platforms }}"
       loop_control:
         label: "{{ item.name }}"
       no_log: false
-
-    # NOTE(retr0h): Vagrant/VBox sucks and parallelizing instance deletion
-    # causes issues.
 
     # Mandatory configuration for Molecule to function.
     - name: Populate instance config

--- a/molecule_vagrant/playbooks/destroy.yml
+++ b/molecule_vagrant/playbooks/destroy.yml
@@ -25,7 +25,6 @@
     # causes issues.
 
     # Mandatory configuration for Molecule to function.
-
     - name: Populate instance config
       set_fact:
         instance_conf: {}

--- a/molecule_vagrant/playbooks/destroy.yml
+++ b/molecule_vagrant/playbooks/destroy.yml
@@ -8,7 +8,7 @@
     - name: Destroy molecule instance(s)
       vagrant:
         instances: "{{ molecule_yml.platforms }}"
-        provider: "{{ molecule_yml.driver.provider.name | default('virtualbox') }}"
+        provider: "{{ molecule_yml.driver.provider.name | default(omit) }}"
         force_stop: "{{ item.force_stop | default(True) }}"
         state: destroy
       register: server

--- a/molecule_vagrant/test/functional/test_func.py
+++ b/molecule_vagrant/test/functional/test_func.py
@@ -51,7 +51,14 @@ def test_command_init_scenario(temp_dir):
 
 
 @pytest.mark.parametrize(
-    "scenario", [("vagrant_root"), ("config_options"), ("provider_config_options")]
+    "scenario",
+    [
+        ("default"),
+        ("vagrant_root"),
+        ("multi-node"),
+        ("config_options"),
+        ("provider_config_options"),
+    ],
 )
 def test_vagrant_root(temp_dir, scenario):
     options = {"scenario_name": scenario}

--- a/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
@@ -9,8 +9,7 @@ lint:
   /bin/true
 platforms:
   - name: instance
-    config_options:
-      synced_folder: true
+    synced_folder: true
     box: centos/7
 provisioner:
   name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
@@ -11,6 +11,10 @@ platforms:
   - name: instance
     synced_folder: true
     box: centos/7
+    networks:
+      - identifier: private_network
+        options:
+          ip: 192.168.0.2
 provisioner:
   name: ansible
 verifier:

--- a/molecule_vagrant/test/scenarios/molecule/default/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: vagrant
   provider:
-    name: virtualbox
+    name: libvirt
 platforms:
   - name: instance
     box: generic/alpine310

--- a/molecule_vagrant/test/scenarios/molecule/default/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default/molecule.yml
@@ -8,6 +8,5 @@ driver:
 platforms:
   - name: instance
     box: generic/alpine310
-    provision: false
 provisioner:
   name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
@@ -6,7 +6,7 @@ driver:
   name: vagrant
   provider:
     name: libvirt
-    parallel: no
+    parallel: false
 
 platforms:
   - name: instance-1
@@ -26,7 +26,7 @@ platforms:
     cpus: 1
     synced_folder: true
     provider_options:
-      qemu_use_session: no
+      qemu_use_session: false
 
   - name: instance-2
     box: centos/7
@@ -44,7 +44,7 @@ platforms:
     memory: 2048
     cpus: 2
     provider_options:
-      qemu_use_session: no
+      qemu_use_session: false
 
 provisioner:
   name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
@@ -1,10 +1,13 @@
 ---
 dependency:
   name: galaxy
+
 driver:
   name: vagrant
   provider:
-    name: virtualbox
+    name: libvirt
+    parallel: no
+
 platforms:
   - name: instance-1
     box: debian/jessie64
@@ -15,14 +18,15 @@ platforms:
           type: dhcp
       - identifier: private_network
         options:
-          virtualbox__intnet: test_network
-          ip: 192.168.0.1
+          ip: 192.168.0.2
     groups:
       - foo
       - bar
     memory: 1024
     cpus: 1
     synced_folder: true
+    provider_options:
+      qemu_use_session: no
 
   - name: instance-2
     box: centos/7
@@ -33,13 +37,15 @@ platforms:
           type: dhcp
       - identifier: private_network
         options:
-          virtualbox__intnet: test_network
-          ip: 192.168.0.2
+          ip: 192.168.0.3
     groups:
       - foo
       - baz
     memory: 2048
     cpus: 2
+    provider_options:
+      qemu_use_session: no
+
 provisioner:
   name: ansible
   config_options:

--- a/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
@@ -16,9 +16,6 @@ platforms:
         options:
           auto_config: true
           type: dhcp
-      - identifier: private_network
-        options:
-          ip: 192.168.0.2
     groups:
       - foo
       - bar
@@ -38,9 +35,6 @@ platforms:
         options:
           auto_config: true
           type: dhcp
-      - identifier: private_network
-        options:
-          ip: 192.168.0.3
     groups:
       - foo
       - baz

--- a/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
@@ -8,29 +8,33 @@ driver:
 platforms:
   - name: instance-1
     box: debian/jessie64
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: dhcp
-      - virtualbox__intnet: test_network
-        network_name: private_network
-        ip: 192.168.0.1
+    networks:
+      - identifier: private_network
+        options:
+          auto_config: true
+          type: dhcp
+      - identifier: private_network
+        options:
+          virtualbox__intnet: test_network
+          ip: 192.168.0.1
     groups:
       - foo
       - bar
     memory: 1024
     cpus: 1
-    config_options:
-      synced_folder: true
+    synced_folder: true
+
   - name: instance-2
     box: centos/7
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: dhcp
-      - virtualbox__intnet: test_network
-        network_name: private_network
-        ip: 192.168.0.2
+    networks:
+      - identifier: private_network
+        options:
+          auto_config: true
+          type: dhcp
+      - identifier: private_network
+        options:
+          virtualbox__intnet: test_network
+          ip: 192.168.0.2
     groups:
       - foo
       - baz

--- a/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
@@ -24,9 +24,12 @@ platforms:
       - bar
     memory: 1024
     cpus: 1
-    synced_folder: true
     provider_options:
       qemu_use_session: false
+    instance_raw_config_args:
+      # We explicitly use rsync instead of the default NFS to avoid needing root
+      # privileges.
+      - "vm.synced_folder '.', '/vagrant', type: 'rsync'"
 
   - name: instance-2
     box: centos/7

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
@@ -10,7 +10,7 @@ lint:
 platforms:
   - name: instance
     provider_options:
-      nic_model_type: '"rtl8139"'
+      nic_model_type: rtl8139
     box: centos/7
 provisioner:
   name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/vagrant_root/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/vagrant_root/molecule.yml
@@ -10,7 +10,6 @@ lint:
 platforms:
   - name: instance
     box: centos/7
-    provision: true
     instance_raw_config_args:
       - "vm.provision :shell, inline: \"echo #{Dir.pwd} > /tmp/workdir\""
 provisioner:


### PR DESCRIPTION
The main purpose of this PR was to refactor the vagrant module to properly support multiple instances with multi-machine `Vagrantfile`'s, though it ended up changing a lot of other things too (sorry about that).

Overview of changes:
- Use templating exclusively instead of the vagrant.yml config file, which has
  been removed. This reduces the amount of code duplication, and makes it simpler to debug bad `Vagrantfile`'s.
- Multiple instances are supported using multi-machine `Vagrantfile`'s instead of overwriting the config files for each instance. This should fix any problems with parallel VM creation.
- Made most of the module options per-instance options to support multiple
  instances better.
- Renamed the `interfaces` to `networks` and changed the structure to:
   ```
   networks:
     - identifier: <network identifier>
       options:
         <option name>: <option value>
   ```
  This matches the naming in the Vagrant [network documentation](https://www.vagrantup.com/docs/networking/basic_usage.html).
- Support for [vagrant-cachier](https://github.com/fgrehm/vagrant-cachier) was removed since the project is unmaintained.
- Enabling VirtualBox's `linked_clone` option by default was removed to simplify the code, since the user can still enable it if they want (not sure about this, maybe we should enable it by default for convenience?).
- The provider setting is now enforced by passing it to `Vagrant.up()`.
- Removed `VagrantClient._status()` since `Vagrant.status()` returns what we want.
- Moved to Python 3 by default.
- Add support for disabling parallel VM creation.
- Re-enabled all of the tests (de6f180), which should now pass.