### PR TITLE
zuul.d/layout.yaml: Make devel non voting

### DIFF
--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -13,6 +13,7 @@
               tox_envlist: packaging
         - molecule-tox-py36-centos-8
         - molecule-tox-py37-fedora-30
-        - molecule-tox-devel-centos-8
+        - molecule-tox-devel-centos-8:
+            voting: false
     gate:
       jobs: *defaults


### PR DESCRIPTION
devel is known to break from time to time and is (at the time of
writing) broken to due a yet-to-be-solved ansible bug.

For instance :
https://6814780d297d9a6f6939-900359be549f0bf1af453961f6c3712c.ssl.cf1.rackcdn.com/2715/aae50fab5869d7e05bb20204060689023dd65382/check/molecule-tox-devel-functional/32d4a18/job-output.html#l1462

So, run the tests but don't make them blocking / vote. This partially revert 4ec068d2f7e8af6c3a9b0f85675c2603fd1211a5
Signed-off-by: Arnaud Patard <apatard@hupstream.com>