### PR TITLE
molecule_vagrant/modules/vagrant.py: Modify the Vagrant{file,.yml} only at creation

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -514,6 +514,9 @@ class VagrantClient(object):
         )
 
     def _write_configs(self):
+        if self._module.params["state"] != "up":
+            return
+
         self._write_vagrantfile_config(self._get_vagrant_config_dict())
         self._write_vagrantfile()
 
@@ -611,6 +614,7 @@ def main():
             force_stop=dict(type="bool", default=False),
             state=dict(type="str", default="up", choices=["up", "destroy", "halt"]),
         ),
+        required_if=[["state", "up", ["platform_box"]]],
         supports_check_mode=False,
     )
 

--- a/molecule_vagrant/test/scenarios/molecule/config_update/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_update/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: sample task  # noqa 305
+      shell:
+        cmd: uname
+        warn: false
+      changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/config_update/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_update/molecule.yml
@@ -1,0 +1,11 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+platforms:
+  - name: instance
+provisioner:
+  name: ansible


### PR DESCRIPTION
The current code is rewriting at every stage the Vagrantfile and
vagrant.yml files. At VM creation stage, it's fine but when destroying,
since the platform_box parameter is optional, this will result in invalid
vagrant.yml: the config.vm.box option will be empty.
Instead of making the platform_box mandatory in creation and halt/destroy
cases, make it mandatory for the VM creation and create/modify only
at this step.

This will possibly fix bug 19 and superseed PR 25 but this has to be
confirmed by the submitter.

The side effects of this commit are:
- it will break the setup of multi node. Multi node support gives the feeling that it's working,
but it reality, it is not. What's happening is that the configuration file is overwritten when
creating/destroying the different nodes (instead of having one Vagrantfile for every
node).
- it will probably conflict with PR 31.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>