### PR TITLE
Fix "Linked cloned cannot be disabled"

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -205,7 +205,7 @@ Vagrant.configure('2') do |config|
       virtualbox.memory = provider_memory
       virtualbox.cpus = provider_cpus
 
-      if provider['options']['linked_clone']
+      if defined?(provider['options']['linked_clone'])
         if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
           virtualbox.linked_clone = provider['options']['linked_clone']
         end


### PR DESCRIPTION
Without this fix, it's impossible to disable VirtualBox Linked Clones.

### To reproduce the issue
```
git clone https://github.com/jpmat296/ansible-upgrade-powershell.git
cd ansible-upgrade-powershell
git checkout demo_bug_molecule
molecule create
```

Note file [molecule.yml](https://github.com/jpmat296/ansible-upgrade-powershell/blob/3fcfa632591dd24c6da5e5b5fac13a0c30f0ee0d/molecule/default/molecule.yml#L8-L9) used contains:
```
    options:
      linked_clone: false
```

### Current behaviour
![image](https://user-images.githubusercontent.com/12024504/93617883-d62fdd00-f9d6-11ea-90ab-afaae79ba037.png)
2 VMs a created because Linked clones are not disabled.

### With the fix
![image](https://user-images.githubusercontent.com/12024504/93617914-ddef8180-f9d6-11ea-86a2-cbb53a1db873.png)
Only one VM is created since linked clones are disabled.

### Related
This issue was already found in issue ansible-community/molecule#1708