### PR TITLE
Avoid unportable /bin/true

### DIFF
--- a/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
@@ -5,8 +5,6 @@ driver:
   name: vagrant
   provider:
     name: libvirt
-lint:
-  /bin/true
 platforms:
   - name: instance
     config_options:

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
@@ -5,8 +5,6 @@ driver:
   name: vagrant
   provider:
     name: libvirt
-lint:
-  /bin/true
 platforms:
   - name: instance
     provider_options:

--- a/molecule_vagrant/test/scenarios/molecule/vagrant_root/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/vagrant_root/molecule.yml
@@ -5,8 +5,6 @@ driver:
   name: vagrant
   provider:
     name: libvirt
-lint:
-  /bin/true
 platforms:
   - name: instance
     box: centos/7


### PR DESCRIPTION
True is a shell command and not an executable on some platforms.
For example on MacOS /bin/true does not exist.