### PR TITLE
Improve CI testing

### DIFF
--- a/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
@@ -12,6 +12,8 @@ platforms:
     provider_options:
       driver: "${VIRT_DRIVER:-'kvm'}"
     box: centos/7
+    instance_raw_config_args:
+      - 'vm.synced_folder ".", "/vagrant", type: "rsync"'
 provisioner:
   name: ansible
 verifier:

--- a/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
@@ -22,6 +22,8 @@ platforms:
     cpus: 1
     config_options:
       synced_folder: true
+    instance_raw_config_args:
+      - 'vm.synced_folder ".", "/vagrant", type: "rsync"'
   - name: instance-2
     box: centos/7
     interfaces:
@@ -36,6 +38,8 @@ platforms:
       - baz
     memory: 2048
     cpus: 2
+    instance_raw_config_args:
+      - 'vm.synced_folder ".", "/vagrant", type: "rsync"'
 provisioner:
   name: ansible
   config_options:

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -128,5 +128,5 @@ vagrant plugin list | tee >(grep -q "No plugins installed." && {
 cd $DIR
 
 # sudo su: dirty hack to make sure that usermod change has been taken into account
-sudo su -l "$(whoami)" -c "cd $(pwd) && timeout 300 vagrant up --no-tty --no-provision"
+sudo su -l "$(whoami)" -c "cd $(pwd) && timeout 300 vagrant up --no-tty --no-provision --debug"
 sudo su -l "$(whoami)" -c "cd $(pwd) && vagrant destroy -f"


### PR DESCRIPTION
This PR contains tweaks to the CI configuration. It's mostly what was in PR44. The qemu fallback patches will be in a different PR.
Important parts are containing:
- synced_folder configuration settings. Got some issues with that with the tests, so force it to use rsync instead of nfs
- change ansible gathering to explicit to speed things up
- change test devel configuration in order to have it run again (even if we know that the test will still fail due to the lock issue)
