### PR TITLE
Disabled pytest capture

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,8 @@ usedevelop = True
 extras = test
 commands =
     pytest --collect-only
-    pytest --color=yes {tty:-s}
+    # -s is added in order to allow live output on long running functional tests
+    pytest --color=yes -s
 setenv =
     ANSIBLE_DISPLAY_FAILED_STDERR=1
     ANSIBLE_VERBOSITY=1


### PR DESCRIPTION
This change should display the output from functional testing in real time, as this may prove important for CI testing too.