### PR TITLE
Remove zuul pypi template

### DIFF
--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -36,8 +36,6 @@
     voting: false
 
 - project:
-    templates:
-      - publish-to-pypi
     check:
       jobs: &defaults
         - molecule-tox-linters:


### PR DESCRIPTION
We will be using github actions for the release pipelines and keep zuul only for testing linux compatibility.