### PR TITLE
Allow linked_cloned to be disabled

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -209,7 +209,7 @@ Vagrant.configure('2') do |config|
       virtualbox.memory = provider_memory
       virtualbox.cpus = provider_cpus
 
-      if provider['options']['linked_clone']
+      if defined?(provider['options']['linked_clone'])
         if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
           virtualbox.linked_clone = provider['options']['linked_clone']
         end

--- a/molecule_vagrant/test/scenarios/molecule/default/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default/molecule.yml
@@ -9,5 +9,7 @@ platforms:
   - name: instance
     box: generic/alpine310
     provision: false
+    options:
+      linked_clone: false
 provisioner:
   name: ansible


### PR DESCRIPTION
This should allow user to disable linked_clone feature.

Based on original PR from https://github.com/ansible-community/molecule-vagrant/pull/45 made by @jpmat296