### PR TITLE
Switch testing nic to e1000

### DIFF
--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
@@ -8,7 +8,7 @@ driver:
 platforms:
   - name: instance
     provider_options:
-      nic_model_type: '"rtl8139"'
+      nic_model_type: '"e1000"'
       driver: "${VIRT_DRIVER:-'kvm'}"
     box: centos/7
 provisioner:

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/verify.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/verify.yml
@@ -9,4 +9,4 @@
   - name: Check network card pci infos
     assert:
       that:
-        - "ansible_facts[iface].module == '8139cp'"
+        - "ansible_facts[iface].module == 'e1000'"


### PR DESCRIPTION
This nic should make testing more portable. Clearly it makes the Github actions pass all tests on MacOS, for the first time.