### PR TITLE
Document Vagrant being unsupported on CentOS 8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,24 @@ Molecule Vagrant Plugin
 Molecule Vagrant is designed to allow use of Vagrant for provisioning of test
 resources.
 
+Supported Platforms
+===================
+
+This driver relies on vagrant command line which is known to be problematic
+to install on several platforms. We do our best to perform CI/CD testing on
+multiple platforms but some are disabled due to known bugs.
+
+* ✅ MacOS with VirtualBox - GitHub Actions
+* ✅ Fedora 32 with libvirt - Zuul
+* ❌ CentOS 8 with libvirt - Zuul DISABLED due to 1127_ and 11020_
+
+Please **do not file bugs for unsupported platforms**. You are welcomed to
+create PRs that fix untested platform, as long they do not break existing ones.
+
+.. _`1127`: https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1127
+.. _`11020`: https://github.com/hashicorp/vagrant/issues/11020
+
+
 Documentation
 =============
 

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -11,25 +11,27 @@
       tox_envlist: py38
     timeout: 3600
 
-- job:
-    name: molecule-vagrant-centos
-    description: Run py36 tox environment
-    parent: ansible-tox-py36
-    nodeset: centos-8-1vcpu
-    attempts: 2
-    vars:
-      tox_envlist: py36
-    timeout: 3600
+# CentOS is unsupported due to:
+# https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1127
+# - job:
+#     name: molecule-vagrant-centos
+#     description: Run py36 tox environment
+#     parent: ansible-tox-py36
+#     nodeset: centos-8-1vcpu
+#     attempts: 2
+#     vars:
+#       tox_envlist: py36
+#     timeout: 3600
 
-- job:
-    name: molecule-vagrant-devel-centos
-    description: Run devel tox environment
-    parent: ansible-tox-py36
-    nodeset: centos-8-1vcpu
-    attempts: 2
-    vars:
-      tox_envlist: devel
-    timeout: 3600
+# - job:
+#     name: molecule-vagrant-devel-centos
+#     description: Run devel tox environment
+#     parent: ansible-tox-py36
+#     nodeset: centos-8-1vcpu
+#     attempts: 2
+#     vars:
+#       tox_envlist: devel
+#     timeout: 3600
 
 - project:
     check:
@@ -38,8 +40,8 @@
             vars:
               test_setup_skip: true
               tox_envlist: lint,packaging
-        - molecule-vagrant-centos
+        # - molecule-vagrant-centos
         - molecule-vagrant-fedora
-        - molecule-vagrant-devel-centos
+        # - molecule-vagrant-devel-centos
     gate:
       jobs: *defaults


### PR DESCRIPTION
Due to lack of support from Vagrant for CentOS 8 we disable testing on that platform and document it. Some power users may be able to get it going but the level of hacking involved makes not suitable for any production environments.

https://github.com/hashicorp/vagrant/issues/11020
https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1127