### PR TITLE
Enable testing with py36 and py39

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,26 +23,11 @@ jobs:
       matrix:
         include:
           - tox_env: lint
-          # - tox_env: docs
-          # - tox_env: py36
-          #   PREFIX: PYTEST_REQPASS=433
-          # - tox_env: py37
-          #   PREFIX: PYTEST_REQPASS=433
-          - tox_env: py38
-            PREFIX: PYTEST_REQPASS=433
-          # - tox_env: py39
-          #   PREFIX: PYTEST_REQPASS=433
-          # - tox_env: packaging
-          # - tox_env: dockerfile
-          # - tox_env: build-containers
-          #   needs:
-          #     - dockerfile
-          #     - docs
-          #     - lint
-          #     - packaging
-          #     - py36
-          #     - py37
-          #     - py38
+          - tox_env: py36
+            PREFIX: PYTEST_REQPASS=5
+          - tox_env: py39
+            PREFIX: PYTEST_REQPASS=5
+          - tox_env: packaging
 
     steps:
       - name: Check vagrant presence

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
     Topic :: System :: Systems Administration
     Topic :: Utilities

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
 minversion = 3.9.0
-envlist = lint,packaging,py36,py37,py38,devel,distros
+envlist = lint,packaging,py{36,37,38,39},devel,distros
 skipsdist = True
 skip_missing_interpreters = True
 isolated_build = True
@@ -43,7 +43,7 @@ passenv =
     CURL_CA_BUNDLE
     DOCKER_*
     HOME
-    PYTEST_OPTIONS
+    PYTEST_*
     REQUESTS_CA_BUNDLE
     SSH_AUTH_SOCK
     SSL_CERT_FILE


### PR DESCRIPTION
We run GitHub CI testing with both minimal an maximal versions of supported Python.