### PR TITLE
molecule_vagrant/modules/vagrant.py: Fix fallback

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -632,7 +632,7 @@ def main():
     if module.params["state"] == "halt":
         v.halt()
 
-    module.exit_json(**module.result)
+    module.fail_json(msg="Unknown error", **v.result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The functions up/destroy/halt of the VagrantClient class
are exiting with proper fail/exit_json but in some cases,
the last line of main() may still be reached and this leads to an
other error since there's no module.result.

While it's not sure how this code is reached, at least fix
that broken line by failing and returning VagrantClient class
result member.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>