### PR TITLE
POC: Use playbook to setup test environment

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,6 +1,8 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
 
+ansible [!platform:centos-8]
+epel-release [platform:centos-8]
 build-essential [platform:dpkg]
 dnsmasq-base [platform:dpkg]
 ebtables [platform:dpkg]

--- a/playbooks/test-setup.yaml
+++ b/playbooks/test-setup.yaml
@@ -1,0 +1,90 @@
+#!/usr/bin/env ansible-playbook
+# Expected to work on: CentOS-8, Fedora-33, Ubuntu-x, MacOSX
+- hosts: localhost
+  handlers:
+    - name: reset-connection
+      when: result is changed
+      meta: reset_connection
+  tasks:
+
+    - when: ansible_distribution != 'MacOSX'
+      block:
+
+        - name: enable libvirtd
+          become: true
+          service:
+            name: libvirtd
+            enabled: true
+            state: started
+
+        - name: Add current user to libvirt group
+          become: true
+          user:
+            name: "{{ lookup('env', 'USER') }}"
+            groups: libvirt
+          register: result
+
+        - name: Trigger connection-reset if needed
+          when: result is changed
+          debug:
+            msg: Performing connection reset
+          notify: reset-connection
+
+        - name: Add libvirt plugin from system
+          when: ansible_distribution == 'Fedora'
+          set_fact:
+            vagrant_packages: "{{ vagrant_packages + ['vagrant-libvirt'] }}"
+
+        - name: Install vagrant from system packages
+          become: true
+          package:
+            name:
+              - vagrant
+              - libxslt-devel
+              - libxml2-devel
+              - libvirt-devel
+              - libguestfs-tools-c
+              - ruby-devel
+              - gcc
+            state: present
+
+        - name: Install vagrant-libvirt plugin
+          when: ansible_distribution != 'Fedora'
+          shell: |
+            export CONFIGURE_ARGS="with-libvirt-include=/usr/include/libvirt with-libvirt-lib=/usr/lib64"
+            vagrant plugin install vagrant-libvirt
+
+    - when: ansible_distribution == 'MacOSX'
+      block:
+        - name: Install vagrant from system packages (MacOS)
+          homebrew_cask:
+            name: vagrant
+            state: installed
+
+        - name: Validate vagrant command
+          shell: |
+            vagrant plugin list
+          register: vagrant_plugins
+          changed_when: false
+
+        - name: Install vagrant virtualbox plugin (MacOS)
+          when: '"No plugins installed." in vagrant_plugins.stdout'
+          shell: |
+            vagrant plugin install virtualbox
+          changed_when: '"Installed the plugin" in result.stdout'
+
+    - name: Validate vagrant command
+      shell: |
+        {% if  ansible_distribution == 'MacOSX' %}
+        export PATH=$PATH:/usr/local/bin
+        {% endif %}
+        vagrant --version
+        vagrant global-status
+        vagrant plugin list
+      register: result
+      changed_when: false
+      failed_when: result.rc != 0 or "No plugins installed." in result.stdout
+
+    - name: Display vagrant information
+      debug:
+        msg: "{{ result.stdout }}"

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,132 +1,22 @@
 #!/bin/bash
 set -euxo pipefail
-# Used by Zuul CI to perform extra bootstrapping
-
-# Platforms coverage:
-# Fedora 30 : has vagrant-libvirt no compilation needed
-# CentOS 7  : install upstream vagrant rpm and compiles plugin (broken runtime)
-# CentOS 8  : install upstream vagrant rpm and compiles plugin (broken runtime)
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# Bumping system tox because version from CentOS 7 is too old
-# We are not using pip --user due to few bugs in tox role which does not allow
-# us to override how is called. Once these are addressed we will switch back
-# non-sudo
-command -v python3 python
+export ANSIBLE_STDOOUT_CALLBACK=yaml
 
-PYTHON=$(command -v python3 python|head -n1)
-PKG_CMD=$(command -v dnf yum apt-get|head -n1)
-
-sudo $PYTHON -m pip install -U tox
-
-# === LIBVIRT SETUP ===
-sudo systemctl enable --now libvirtd
-sudo usermod --append --groups libvirt "$(whoami)"
-
-# only info about the virtualisation is wanted, so no error please.
-sudo virt-host-validate qemu || true
-
-# === VAGRANT SETUP ===
-# Install Vagrant using their questionable practices, see locked ticket:
-# https://github.com/hashicorp/vagrant/issues/11070
-
-which vagrant || \
-    sudo $PKG_CMD install -y vagrant-libvirt || {
-        sudo $PKG_CMD install -y https://releases.hashicorp.com/vagrant/2.2.10/vagrant_2.2.10_x86_64.rpm
-    }
-
-if [ -f /etc/os-release ]; then
-    source /etc/os-release
-    case "$NAME" in
-        Ubuntu)
-            case "$VERSION_ID" in
-                18.04)
-                    # ubuntu xenial vagrant is too old so it doesn't support triggers, used by the alpine box
-                    sudo apt-get remove --purge -y vagrant
-                    wget --no-show-progress https://releases.hashicorp.com/vagrant/2.2.9/vagrant_2.2.9_x86_64.deb
-                    sudo dpkg -i vagrant_2.2.9_x86_64.deb
-                    ;;
-                *)
-                    ;;
-            esac
-            ;;
-        Fedora)
-            case "$VERSION_ID" in
-                31)
-                    # https://bugzilla.redhat.com/show_bug.cgi?id=1839651
-                    sudo $PKG_CMD upgrade -y --enablerepo=updates-testing --advisory=FEDORA-2020-09c472786c
-                    ;;
-                *)
-                    ;;
-            esac
-            ;;
-        CentOS*)
-            # https://github.com/hashicorp/vagrant/issues/11020
-            if grep -qi '^CentOS Linux release 8.2.*' /etc/centos-release ; then
-                # https://bugs.centos.org/view.php?id=17120
-                relver="$(cat /etc/centos-release | awk '{print $4}')"
-                sudo sed -i /etc/yum.repos.d/CentOS-Sources.repo -e 's,$contentdir/,,g'
-                sudo sed -i /etc/yum.repos.d/CentOS-Sources.repo -e "s,\$releasever,$relver,g"
-
-                sudo dnf install -y rpm-build autoconf libselinux-devel pam-devel bison byacc
-                mkdir -p "$HOME/rpmbuild/SOURCES"
-                cd "$HOME/rpmbuild/SOURCES"
-                # download as root to avoid the "error: [Errno 13] Permission denied: '/var/cache/dnf/expired_repos.json'"
-                sudo dnf download --enablerepo=BaseOS-source --disablerepo=epel-source --disablerepo=epel --source krb5-libs
-                rpm2cpio krb5-1.17-*.src.rpm | cpio -idv
-                # remove patch making incompatible with the openssl bundled with vagrant
-                sed -i ./krb5.spec -e 's,Patch.*Use-backported-version-of-OpenSSL-3-KDF-interface.patch,,'
-                # depends on previous patch
-                sed -i ./krb5.spec -e 's,Patch.*krb5-1.17post2-DES-3DES-fixups.patch,,'
-                # not sure why but makes the build fail
-                sed -i ./krb5.spec -e 's,Patch.*krb5-1.17post6-FIPS-with-PRNG-and-RADIUS-and-MD4.patch,,'
-                rpmbuild -bp krb5.spec --nodeps
-                cd ../BUILD/krb5-1.17/src
-                # Some flags are missing compared to the spec but these ones seem to be enough
-                export CFLAGS="-I/opt/vagrant/embedded/include/ -fPIC -fno-strict-aliasing -fstack-protector-all"
-                export LDFLAGS=-L/opt/vagrant/embedded/lib64/
-                ./configure --prefix=/opt/vagrant/embedded/
-                make
-                sudo cp -a lib/crypto/libk5crypto.so.3* /opt/vagrant/embedded/lib64/
-            fi
-            ;;
-        *)
-            ;;
-    esac
-fi
-
-vagrant plugin list | grep vagrant-libvirt || {
-    export CONFIGURE_ARGS="with-libvirt-include=/usr/include/libvirt with-libvirt-lib=/usr/lib64"
-    if [ -x /opt/vagrant/bin/vagrant ]; then
-        # command line from https://github.com/vagrant-libvirt/vagrant-libvirt#installation
-        export GEM_HOME=~/.vagrant.d/gems
-        export GEM_PATH=$GEM_HOME:/opt/vagrant/embedded/gems
-        export PATH=/opt/vagrant/embedded/bin:$PATH
-        export CONFIGURE_ARGS='with-ldflags=-L/opt/vagrant/embedded/lib with-libvirt-include=/usr/include/libvirt with-libvirt-lib=/usr/lib'
-    fi
-    vagrant plugin install vagrant-libvirt
+# bindep does only install epel-release fron centos-8, so we need to help it
+which ansible-playbook || {
+  sudo dnf install -y ansible
 }
 
-if [ -f /etc/debian_version ]; then
-    dpkg -l | grep libselinux
-    [ -x /usr/bin/aa-enabled ] && echo "Apparmor: `/usr/bin/aa-enabled`"
-else
-    rpm -qa | grep libselinux
-fi
-
-vagrant version
-vagrant global-status
-
-vagrant plugin list | tee >(grep -q "No plugins installed." && {
-    echo "FATAL: Vagrant is not usable without any provider plugins."
-    exit 1
-})
+ansible-playbook -v "${DIR}/../playbooks/test-setup.yaml"
 
 # Used to test that Vagrant is usable and also to pre-download the image
 # we will use during testing.
-cd $DIR
+cd "$DIR"
 
 # sudo su: dirty hack to make sure that usermod change has been taken into account
-sudo su -l "$(whoami)" -c "cd $(pwd) && timeout 300 vagrant up --no-tty --no-provision --debug"
-sudo su -l "$(whoami)" -c "cd $(pwd) && vagrant destroy -f"
+# sudo su -l "$(whoami)" -c "cd $(pwd) && timeout 300 vagrant up --no-tty --no-provision --debug"
+# sudo su -l "$(whoami)" -c "cd $(pwd) && vagrant destroy -f"
+timeout 300 vagrant up --no-tty --no-provision --debug
+vagrant destroy -f

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -13,15 +13,15 @@
 
 # CentOS is unsupported due to:
 # https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1127
-# - job:
-#     name: molecule-vagrant-centos
-#     description: Run py36 tox environment
-#     parent: ansible-tox-py36
-#     nodeset: centos-8-1vcpu
-#     attempts: 2
-#     vars:
-#       tox_envlist: py36
-#     timeout: 3600
+- job:
+    name: molecule-vagrant-centos
+    description: Run py36 tox environment
+    parent: ansible-tox-py36
+    nodeset: centos-8-1vcpu
+    attempts: 2
+    vars:
+      tox_envlist: py36
+    timeout: 3600
 
 # - job:
 #     name: molecule-vagrant-devel-centos


### PR DESCRIPTION
This change is not ready for review but was created because the bash file was getting out of control, having too much logic in it.

I do not expect this to be merged any time soon, but we can use it to write a vagrant bootstrapping solution, something that we need for our own testing.