### PR TITLE
Manually set cpu to qemu64 with qemu driver

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -321,6 +321,18 @@ Vagrant.configure('2') do |config|
       provider['options'].each { |key, value|
         eval("libvirt.#{key} = #{value}")
       }
+      # When using qemu instead of kvm, some libvirt systems
+      # will use EPYC as vCPU model inside the new VM.
+      # This will lead to process hang with ssh-keygen -A on alpine.
+      # Not sure were the bug is (libvirt or qemu or alpine or all of them) but using QEMU64
+      # cpu model will work around this. Hopefully, by checking 'cpu_mode' option, it will
+      # allow people to override the model to use.
+      if defined?(provider['options']['driver']) && provider['options']['driver'].include?('qemu')
+        if !provider['options']['cpu_mode']
+          libvirt.cpu_mode = 'custom'
+          libvirt.cpu_model = 'qemu64'
+        end
+      end
 
       # Raw Configuration
       if provider['raw_config_args']

--- a/tools/Vagrantfile
+++ b/tools/Vagrantfile
@@ -5,6 +5,6 @@ Vagrant.configure("2") do |config|
     l.nic_model_type = "e1000"
     l.driver = "qemu"
     l.cpu_mode = 'custom'
-    l.cpu_model = 'core2duo'
+    l.cpu_model = 'qemu64'
   end
 end


### PR DESCRIPTION
When TCG is used instead of KVM, libvirt defaults to using the EPYC
cpu model on some systems (even if the host is an intel cpu). This
leads to some weird issues, like ssh-keygen -A hanging at the
boot of alpine VM in the CI.
In previous works, I've work arounded the issue by switching the VM to
using centos instead of alpine but I think it's a good idea to
provide good working default, so the vCPU model is set to qemu64
when TCG is used, if the vCPU model is not specified.
The tools/Vagrantfile has been updated to match this vCPU model too.

Side-note: I'm still wondering if the same thing should be done for
systems without KVM, aka automatically default to TCG in this case.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>