### PR TITLE
Fix run_command import due to move

### DIFF
--- a/molecule_vagrant/test/functional/test_func.py
+++ b/molecule_vagrant/test/functional/test_func.py
@@ -24,7 +24,8 @@ import os
 
 from molecule import util
 from molecule import logger
-from molecule.test.conftest import run_command, change_dir_to
+from molecule.util import run_command
+from molecule.test.conftest import change_dir_to
 
 LOG = logger.get_logger(__name__)
 


### PR DESCRIPTION
Molecule 3.2.0a1 moved run_command to molecule.util, so update the
test code to reflect that.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>