### PR TITLE
Vagrant yaml removal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,12 +86,15 @@ Here's a full example with the libvirt provider:
            host: 8080
        # List of raw Vagrant `config` options
        instance_raw_config_args:
-         - 'vagrant.plugins = ["vagrant-libvirt"]'
+         - vagrant.plugins = ["vagrant-libvirt"]
+         # use single quotes to avoid YAML parsing as dict due to ':'
+         - 'vm.synced_folder ".", "/vagrant", type: "rsync"'
        # Dictionary of `config` options. Note that string values need to be
        # explicitly enclosed in quotes.
        config_options:
          ssh.keep_alive: yes
-         ssh.remote_user: "'vagrant'"
+         ssh.remote_user: 'vagrant'
+         synced_folder: true
        box: fedora/32-cloud-base
        box_version: 32.20200422.0
        box_url:
@@ -99,10 +102,10 @@ Here's a full example with the libvirt provider:
        cpus: 1
        # Dictionary of options passed to the provider
        provider_options:
-         video_type: "'vga'"
+         video_type: 'vga'
        # List of raw provider options
        provider_raw_config_args:
-         - "cpuset = '1-4,^3,6'"
+         - cpuset = '1-4,^3,6'
        provision: no
 
 .. _`fedora/32-cloud-base`: https://app.vagrantup.com/fedora/boxes/32-cloud-base

--- a/molecule_vagrant/driver.py
+++ b/molecule_vagrant/driver.py
@@ -160,7 +160,6 @@ class Vagrant(Driver):
     def default_safe_files(self):
         return [
             self.vagrantfile,
-            self.vagrantfile_config,
             self.instance_config,
             os.path.join(self._config.scenario.ephemeral_directory, ".vagrant"),
             os.path.join(self._config.scenario.ephemeral_directory, "vagrant-*.out"),
@@ -198,10 +197,6 @@ class Vagrant(Driver):
     @property
     def vagrantfile(self):
         return os.path.join(self._config.scenario.ephemeral_directory, "Vagrantfile")
-
-    @property
-    def vagrantfile_config(self):
-        return os.path.join(self._config.scenario.ephemeral_directory, "vagrant.yml")
 
     def _get_instance_config(self, instance_name):
         instance_config_dict = util.safe_load_file(self._config.driver.instance_config)

--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -546,6 +546,16 @@ class VagrantClient(object):
     def _write_configs(self):
         self._write_vagrantfile_config(self._get_vagrant_config_dict())
         self._write_vagrantfile()
+        valid = subprocess.run(
+            ["vagrant", "validate"],
+            cwd=self._config["workdir"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if valid.returncode != 0:
+            self._module.fail_json(
+                msg="Failed to validate generated Vagrantfile: {}".format(valid.stderr)
+            )
 
     def _get_vagrant(self):
         v = vagrant.Vagrant(

--- a/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     config_options:
       synced_folder: true
     provider_options:
-      driver: "${VIRT_DRIVER:-'kvm'}"
+      driver: ${VIRT_DRIVER:-kvm}
     box: ${TESTBOX:-centos/7}
     instance_raw_config_args:
       - 'vm.synced_folder ".", "/vagrant", type: "rsync"'

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
@@ -8,8 +8,8 @@ driver:
 platforms:
   - name: instance
     provider_options:
-      nic_model_type: '"e1000"'
-      driver: "${VIRT_DRIVER:-'kvm'}"
+      nic_model_type: e1000
+      driver: ${VIRT_DRIVER:-kvm}
     box: ${TESTBOX:-centos/7}
 provisioner:
   name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/vagrant_root/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/vagrant_root/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: instance
     box: ${TESTBOX:-centos/7}
     provider_options:
-      driver: "${VIRT_DRIVER:-'kvm'}"
+      driver: ${VIRT_DRIVER:-kvm}
     provision: true
     instance_raw_config_args:
       - "vm.provision :shell, inline: \"echo #{Dir.pwd} > /tmp/workdir\""


### PR DESCRIPTION
    molecule_vagrant/modules/vagrant.py: Kill vagrant.yml
    
    Using a vagrant.yml file to store the instance configuration
    is adding an useless overhead and make things harder to debug.
    
    While moving the Vagrantfile generation to use only jinja2 templating,
    remove the hardcoded vagrant provider handling, since only vmware
    providers are different (cpu and memory are 'vmx['numvcpus']' and
    vmx['memsize']).
    
    The new way of generating vagrant configuration will also ease to
    improve the multiplatform support.
    
    Notes:
    - special vagrant-vbguest handling with virtualvbox provider removed
    - to remain "bug" compatible for now, things like nic_model_type: '"e1000"'
      are still working, even if the new way is nic_model_type: e1000 (or "e1000").
      This will maybe vanish with multiplatform, since it'll probably introduce
      breakage due to different module arguments.
    
    Fixes: #86
    Signed-off-by: Arnaud Patard <apatard@hupstream.com>