### PR TITLE
[WIP] add support for box_download_checksum

### DIFF
--- a/molecule_vagrant/driver.py
+++ b/molecule_vagrant/driver.py
@@ -75,6 +75,8 @@ class Vagrant(Driver):
             box: debian/jessie64
             box_version: 10.1
             box_url: http://repo.example.com/images/postmerge/debian.json
+            box_download_checksum: 6d016aa287990152548f0a414048c2edeea7f84b48293cab21506f86649f79b8
+            box_download_checksum_type: sha256
             memory: 1024
             cpus: 1
             provider_options:

--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -94,6 +94,16 @@ options:
       - The URL to a Vagrant box.
     required: False
     default: None
+  platform_box_download_checksum:
+    description:
+      - The checksum of the box specified by platform_box_url.
+    required: False
+    default: None
+  platform_box_download_checksum_type:
+    description:
+      - The type of checksum specified by platform_box_download_checksum (if any).
+    required: False
+    default: None
   provider_name:
     description:
       - Name of the Vagrant provider to use.
@@ -188,6 +198,14 @@ Vagrant.configure('2') do |config|
 
   if platform['box_url']
     config.vm.box_url = platform['box_url']
+  end
+
+  if platform['box_download_checksum']
+    config.vm.box_download_checksum = platform['box_download_checksum']
+  end
+
+  if platform['box_download_checksum_type']
+    config.vm.box_download_checksum_type = platform['box_download_checksum_type']
   end
 
   ##
@@ -573,6 +591,12 @@ class VagrantClient(object):
                 "box": self._module.params["platform_box"],
                 "box_version": self._module.params["platform_box_version"],
                 "box_url": self._module.params["platform_box_url"],
+                "box_download_checksum": self._module.params[
+                    "platform_box_download_checksum"
+                ],
+                "box_download_checksum_type": self._module.params[
+                    "platform_box_download_checksum_type"
+                ],
             },
             "instance": {
                 "name": self._module.params["instance_name"],
@@ -630,6 +654,8 @@ def main():
             platform_box=dict(type="str", required=False),
             platform_box_version=dict(type="str"),
             platform_box_url=dict(type="str"),
+            platform_box_download_checksum=dict(type="str"),
+            platform_box_download_checksum_type=dict(type="str"),
             provider_name=dict(type="str", default="virtualbox"),
             provider_memory=dict(type="int", default=512),
             provider_cpus=dict(type="int", default=2),

--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -16,6 +16,8 @@
         platform_box: "{{ item.box | default('generic/alpine310') }}"
         platform_box_version: "{{ item.box_version | default(omit) }}"
         platform_box_url: "{{ item.box_url | default(omit) }}"
+        platform_box_download_checksum: "{{ item.box_download_checksum | default(omit) }}"
+        platform_box_download_checksum_type: "{{ item.box_download_checksum_type | default(omit) }}"
 
         provider_name: "{{ molecule_yml.driver.provider.name | default(omit, true) }}"
         provider_memory: "{{ item.memory | default(omit) }}"


### PR DESCRIPTION
Add support for `config.vm.box_download_checksum` and `config.vm.box_download_checksum_type` (https://www.vagrantup.com/docs/vagrantfile/machine_settings#config-vm-box_download_checksum).

```yaml
platforms:
  - name: centos-stream
    provider_options:
      vm.boot_timeout: 600
    instance_raw_config_args:
      - 'vbguest.installer_options = { allow_kernel_upgrade: true }'
    memory: 1024
    box: "centos-stream/20201019"
    box_url: "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20201019.1.x86_64.vagrant-virtualbox.box"
    box_download_checksum: "96d388ff2170430f032149323ffbba20309b8e0da924e1ad6ec5f024936c2648"
    box_download_checksum_type: "sha256"
```

Incorrect checksum:

```
TASK [Create molecule instance(s)] *********************************************
Friday 11 December 2020  16:01:52 +0100 (0:00:00.023)       0:00:00.023 *******
failed: [localhost] (item=centos-stream) => {"ansible_loop_var": "item", "changed": false, "cmd": ["/usr/local/bin/vagrant", "up", "--no-provision"], "item": {"box": "centos-stream/20201019", "box_download_checksum": "88d388ff2170430f032149323ffbba20309b8e0da924e1ad6ec5f024936c2648", "box_download_checksum_type": "sha256", "box_url": "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20201019.1.x86_64.vagrant-virtualbox.box", "instance_raw_config_args": ["vbguest.installer_options = { allow_kernel_upgrade: true }"], "memory": 1024, "name": "centos-stream", "provider_options": {"vm.boot_timeout": 600}}, "msg": "Failed to start the VM: See log file '/Users/xxxxx/.cache/molecule/ansible-role-hardening/centos/vagrant-centos-stream.err'", "rc": 1, "stderr": "### 2020-12-11 09:49:36 ###\n### 2020-12-11 11:31:33 ###\n### 2020-12-11 14:26:22 ###\n### 2020-12-11 14:33:59 ###\n### 2020-12-11 14:33:59 ###\n### 2020-12-11 14:33:59 ###\n### 2020-12-11 14:51:53 ###\n### 2020-12-11 14:51:53 ###\n### 2020-12-11 14:51:53 ###\n### 2020-12-11 14:57:02 ###\n### 2020-12-11 15:00:05 ###\n### 2020-12-11 15:10:34 ###\n### 2020-12-11 15:13:17 ###\n### 2020-12-11 15:21:54 ###\n### 2020-12-11 15:32:38 ###\n### 2020-12-11 15:51:53 ###\n### 2020-12-11 15:51:53 ###\n### 2020-12-11 15:51:53 ###\n### 2020-12-11 15:58:44 ###\n### 2020-12-11 15:58:44 ###\n### 2020-12-11 15:58:44 ###\n### 2020-12-11 16:02:36 ###\n### 2020-12-11 16:02:36 ###\nThe checksum of the downloaded box did not match the expected\nvalue. Please verify that you have the proper URL setup and that\nyou're downloading the proper file.\n\nExpected: 88d388ff2170430f032149323ffbba20309b8e0da924e1ad6ec5f024936c2648\nReceived: 96d388ff2170430f032149323ffbba20309b8e0da924e1ad6ec5f024936c2648\n", "stderr_lines": ["### 2020-12-11 09:49:36 ###", "### 2020-12-11 11:31:33 ###", "### 2020-12-11 14:26:22 ###", "### 2020-12-11 14:33:59 ###", "### 2020-12-11 14:33:59 ###", "### 2020-12-11 14:33:59 ###", "### 2020-12-11 14:51:53 ###", "### 2020-12-11 14:51:53 ###", "### 2020-12-11 14:51:53 ###", "### 2020-12-11 14:57:02 ###", "### 2020-12-11 15:00:05 ###", "### 2020-12-11 15:10:34 ###", "### 2020-12-11 15:13:17 ###", "### 2020-12-11 15:21:54 ###", "### 2020-12-11 15:32:38 ###", "### 2020-12-11 15:51:53 ###", "### 2020-12-11 15:51:53 ###", "### 2020-12-11 15:51:53 ###", "### 2020-12-11 15:58:44 ###", "### 2020-12-11 15:58:44 ###", "### 2020-12-11 15:58:44 ###", "### 2020-12-11 16:02:36 ###", "### 2020-12-11 16:02:36 ###", "The checksum of the downloaded box did not match the expected", "value. Please verify that you have the proper URL setup and that", "you're downloading the proper file.", "", "Expected: 88d388ff2170430f032149323ffbba20309b8e0da924e1ad6ec5f024936c2648", "Received: 96d388ff2170430f032149323ffbba20309b8e0da924e1ad6ec5f024936c2648"]}
```

Correct checksum:

```
TASK [Create molecule instance(s)] *********************************************
Friday 11 December 2020  17:14:51 +0100 (0:00:00.034)       0:00:00.034 *******
changed: [localhost] => (item=centos-stream)

TASK [Populate instance config dict] *******************************************
Friday 11 December 2020  17:22:18 +0100 (0:07:26.405)       0:07:26.439 *******
ok: [localhost] => (item={'changed': True, 'log': '/Users/xxxxx/.cache/molecule/ansible-role-hardening/centos/vagrant-centos-stream.out', 'Host': 'centos-stream', 'HostName': '127.0.0.1', 'User': 'vagrant', 'Port': '2200', 'UserKnownHostsFile': '/dev/null', 'StrictHostKeyChecking': 'no', 'PasswordAuthentication': 'no', 'IdentityFile': '/Users/xxxxx/.cache/molecule/ansible-role-hardening/centos/.vagrant/machines/centos-stream/virtualbox/private_key', 'IdentitiesOnly': 'yes', 'LogLevel': 'FATAL', 'invocation': {'module_args': {'instance_name': 'centos-stream', 'instance_raw_config_args': ['vbguest.installer_options = { allow_kernel_upgrade: true }'], 'platform_box': 'centos-stream/20201019', 'platform_box_url': 'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20201019.1.x86_64.vagrant-virtualbox.box', 'platform_box_download_checksum': '96d388ff2170430f032149323ffbba20309b8e0da924e1ad6ec5f024936c2648', 'platform_box_download_checksum_type': 'sha256', 'provider_name': 'VBox', 'provider_memory': 1024, 'provider_options': {'vm.boot_timeout': 600}, 'state': 'up', 'instance_interfaces': [], 'config_options': {}, 'provider_cpus': 2, 'provision': False, 'force_stop': False, 'platform_box_version': None, 'provider_override_args': None, 'provider_raw_config_args': None, 'workdir': None}}, 'failed': False, 'item': {'box': 'centos-stream/20201019', 'box_download_checksum': '96d388ff2170430f032149323ffbba20309b8e0da924e1ad6ec5f024936c2648', 'box_download_checksum_type': 'sha256', 'box_url': 'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20201019.1.x86_64.vagrant-virtualbox.box', 'instance_raw_config_args': ['vbguest.installer_options = { allow_kernel_upgrade: true }'], 'memory': 1024, 'name': 'centos-stream', 'provider_options': {'vm.boot_timeout': 600}}, 'ansible_loop_var': 'item'})
```

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>