### PR TITLE
providers need to be in lower case

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ Here's a full example with the libvirt provider:
      name: vagrant
      provider:
        # Can be any supported provider (VBox, Parallels, libvirt, etc)
+       # in lower case
        name: libvirt
 
    platforms:


### PR DESCRIPTION
Kind of a silly PR, but using `VBox` instead of `vbox` was a waste of a couple of hours.

closes #91


Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>