### PR TITLE
molecule_vagrant/modules/vagrant.py: Force lower case when using provider.name as variable

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -216,22 +216,22 @@ Vagrant.configure('2') do |config|
     ##
     # Provider
     ##
-    c.vm.provider "{{ instance.provider }}" do |{{ instance.provider }}, override|
+    c.vm.provider "{{ instance.provider }}" do |{{ instance.provider | lower }}, override|
       {% if instance.provider.startswith('vmware_') %}
-      {{ instance.provider }}.vmx['memsize'] = {{ instance.memory }}
-      {{ instance.provider }}.vmx['numvcpus'] = {{ instance.cpus }}
+      {{ instance.provider | lower }}.vmx['memsize'] = {{ instance.memory }}
+      {{ instance.provider | lower }}.vmx['numvcpus'] = {{ instance.cpus }}
       {% else %}
-      {{ instance.provider }}.memory = {{ instance.memory }}
-      {{ instance.provider }}.cpus = {{ instance.cpus }}
+      {{ instance.provider | lower }}.memory = {{ instance.memory }}
+      {{ instance.provider | lower }}.cpus = {{ instance.cpus }}
       {% endif %}
 
       {% for option, value in instance.provider_options.items() %}
-      {{ instance.provider }}.{{ option }} = {{ ruby_format(value) }}
+      {{ instance.provider | lower }}.{{ option }} = {{ ruby_format(value) }}
       {% endfor %}
 
       {% if instance.provider_raw_config_args is not none %}
         {% for arg in instance.provider_raw_config_args %}
-      {{ instance.provider }}.{{ arg }}
+      {{ instance.provider | lower }}.{{ arg }}
         {% endfor %}
       {% endif %}
 


### PR DESCRIPTION

When using {{ instance.provider }} as variable in the generated
Vagrantfile, it has to respect ruby syntax, so the first letter
has to be a lower case.

Until recently, either the user was using the provider name as the one
specified in the Vagrant documentation or it was specifying the
wrong name (like VirtualBox or VBox) and things were "just" working,
since Vagrant will default to virtualbox in case it didn't find the
configured provider.
In the vagrant.yml removal patch, I've used the provider name as variable
and with the provider set to 'VirtualBox', this will now produced the
following ruby error:

Vagrantfile:45: formal argument cannot be a constant

So, even if it may be considered as a configuration error, it's
better to ensure on our side to not produce an invalid file.
The change is limited to this part of the Vagrantfile, as I guess
that user will respect the casing for the other configuration options.

Fix: #91
Signed-off-by: Arnaud Patard <apatard@hupstream.com>