### PR TITLE
Clarify string value declarations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Here's a full example with the libvirt provider:
        # away we need to quote string values twice.
        config_options:
          ssh.keep_alive: yes
-         ssh.remote_user: "'vagrant'"
+         ssh.remote_user: vagrant
          synced_folder: true
          cachier: false  # disable cachier plugin, if it's detected
        box: fedora/32-cloud-base

--- a/README.rst
+++ b/README.rst
@@ -90,10 +90,11 @@ Here's a full example with the libvirt provider:
          # use single quotes to avoid YAML parsing as dict due to ':'
          - 'vm.synced_folder ".", "/vagrant", type: "rsync"'
        # Dictionary of `config` options. Note that string values need to be
-       # explicitly enclosed in quotes.
+       # explicitly enclosed in quotes. To protect the quotes from being parsed
+       # away we need to quote string values twice.
        config_options:
          ssh.keep_alive: yes
-         ssh.remote_user: 'vagrant'
+         ssh.remote_user: "'vagrant'"
          synced_folder: true
          cachier: false  # disable cachier plugin, if it's detected
        box: fedora/32-cloud-base


### PR DESCRIPTION
As already stated string values need to be enclosed in quotes; otherwise the value might be interpreted as variable or method name (cf. [[1]]). However, since single- and double-quoted values are parsed as scalars in YAML the quotes are effectively removed (cf. examples in [[2]]). This leads to the following error:

    Vagrant failed to initialize at a very early stage:

    There was an error loading a Vagrantfile. The file being loaded
    and the error message are shown below. This is usually caused by
    an invalid or undefined variable.

    Path: (eval)
    Line number: 1
    Message: undefined local variable or method `vagrant'

By enclosing the value with a second pair of quotes the innermost quotes are passed to Vagrant as required.

[1]: https://github.com/hashicorp/vagrant/issues/8721#issuecomment-313246936
[2]: https://yaml.org/spec/1.2/spec.html#id2786942