### PR TITLE
molecule_vagrant/playbooks/prepare.yml: Better error handling

### DIFF
--- a/molecule_vagrant/playbooks/prepare.yml
+++ b/molecule_vagrant/playbooks/prepare.yml
@@ -12,7 +12,12 @@
         (test -e /usr/bin/yum && sudo yum -y -qq install python3) ||
         (test -e /usr/sbin/pkg && sudo env ASSUME_ALWAYS_YES=yes pkg update && sudo env ASSUME_ALWAYS_YES=yes pkg install python3) ||
         (test -e /usr/sbin/pkg_add && sudo /usr/sbin/pkg_add -U -I -x python%3.7) ||
-        echo "Warning: Python not bootstrapped due to unknown platform."
+        echo "ERROR: Python not bootstrapped due to unknown platform." && exit 234
         )
       become: true
       changed_when: false
+      retries: 3
+      delay: 10
+      register: python_bootstrap
+      until: python_bootstrap.rc != 234
+      ignore_errors: true


### PR DESCRIPTION
Currently, if python installation fails, no error or message is
returned and ansible will fail to execute following tasks since
python is not there.
As a solution, make the raw: command file and retry it 3 times
in case of failure. To keep current behaviour, ignore errors.

With that, it should be easier to spot installation errors in
the logs and python bootstrap should be more robust.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>