### PR TITLE
molecule_vagrant/modules/vagrant.py: don't use boolean jinja test

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -162,7 +162,7 @@ See doc/source/configuration.rst
 
 VAGRANTFILE_TEMPLATE = """
 {%- macro ruby_format(value) -%}
-  {%- if value is boolean -%}
+  {%- if value is sameas true or value is sameas false -%}
     {{ value | string | lower }}
   {%- elif value is string -%}
     {# "Bug" compat. To be removed later #}


### PR DESCRIPTION
On one of my test env, got a failure from jinja:
The error was: jinja2.exceptions.TemplateAssertionError: no test named 'boolean'

So, check that the value is same as true or false instead of testing
'boolean' type.

I'm not exactly sure where the culprit is but the change should be harmless.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>