### PR TITLE
molecule: Make link point to molecule_vagrant/test/scenarios/molecule/

### DIFF
--- a/molecule
+++ b/molecule
@@ -1,1 +1,1 @@
-../molecule-vagrant/molecule_vagrant/test/scenarios/molecule
+molecule_vagrant/test/scenarios/molecule/


### PR DESCRIPTION
Current link is pointing ../molecule-vagrant/..., which is working
nicely with a clone of the project, but if the clone is done to a
directory, say bug99999, the link will be broken.
I'm not sure what's the exact purpose of this link but I'm using it a
lot to run CI test scenarii and changing the link everytime is painful.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>