### PR TITLE
Spell out VirtualBox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Here's a full example with the libvirt provider:
    driver:
      name: vagrant
      provider:
-       # Can be any supported provider (VirtualBox, Parallels, libvirt, etc)
+       # Can be any supported provider (virtualbox, parallels, libvirt, etc)
        name: libvirt
 
    platforms:

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Here's a full example with the libvirt provider:
    driver:
      name: vagrant
      provider:
-       # Can be any supported provider (VBox, Parallels, libvirt, etc)
+       # Can be any supported provider (VirtualBox, Parallels, libvirt, etc)
        name: libvirt
 
    platforms:

--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -35,7 +35,7 @@
         label: "{{ item.name }}"
       no_log: false
 
-    # NOTE(retr0h): Vagrant/VBox sucks and parallelizing instance creation
+    # NOTE(retr0h): Vagrant/VirtualBox sucks and parallelizing instance creation
     # causes issues.
 
     # Mandatory configuration for Molecule to function.

--- a/molecule_vagrant/playbooks/destroy.yml
+++ b/molecule_vagrant/playbooks/destroy.yml
@@ -21,7 +21,7 @@
         label: "{{ item.name }}"
       no_log: false
 
-    # NOTE(retr0h): Vagrant/VBox sucks and parallelizing instance deletion
+    # NOTE(retr0h): Vagrant/VirtualBox sucks and parallelizing instance deletion
     # causes issues.
 
     # Mandatory configuration for Molecule to function.


### PR DESCRIPTION
This PR:
- replaces VBox with VirtualBox
- closes #115 
- is related to #91  
- helps slow folks like me understand the examples

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>