### PR TITLE
Ensure jinja2 >= 2.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ setup_requires =
 install_requires =
     molecule >= 3.2.0a0
     pyyaml >= 5.1, < 6
+    Jinja2 >= 2.11.3
     selinux
 
 [options.extras_require]


### PR DESCRIPTION
The vagrant module is using Jinja2 boolean test and it's available for
2.11+ only, so ensure this minimal version is installed.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>