### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @ssbarnea @apatard


### PR DESCRIPTION
Set Sorin and I in CODEOWNERS, to get some reviewers automatically assigned.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>