### PR TITLE
CI: select nodes with at least 4Go

### DIFF
--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -2,10 +2,10 @@
 # zuul.d/layout.yaml
 
 - job:
-    name: molecule-vagrant-fedora
+    name: molecule-vagrant-ubuntu-bionic-py38
     description: Run py38 tox environment
     parent: ansible-tox-py38
-    nodeset: fedora-latest-1vcpu
+    nodeset: ubuntu-bionic-4vcpu
     attempts: 2
     vars:
       tox_envlist: py38
@@ -34,10 +34,10 @@
 #     timeout: 3600
 
 - job:
-    name: molecule-vagrant-ubuntu-bionic
+    name: molecule-vagrant-ubuntu-bionic-py36
     description: Run py36 tox environment
     parent: ansible-tox-py36
-    nodeset: ubuntu-bionic-1vcpu
+    nodeset: ubuntu-bionic-4vcpu
     attempts: 2
     vars:
       tox_envlist: py36
@@ -47,6 +47,7 @@
     check:
       jobs: &defaults
         # - molecule-vagrant-centos
-        - molecule-vagrant-fedora
+        # - molecule-vagrant-fedora
         # - molecule-vagrant-devel-centos
-        - molecule-vagrant-ubuntu-bionic
+        - molecule-vagrant-ubuntu-bionic-py38
+        - molecule-vagrant-ubuntu-bionic-py36


### PR DESCRIPTION
2Go [aren't sufficient](https://dashboard.zuul.ansible.com/t/ansible/build/c9876f368cd341b488153ed5ad066f4e) to create the 2Go virtual machine. Besides the `ubuntu-bionic-1vcpu` label uses virtual machines with [1Go only](https://dashboard.zuul.ansible.com/t/ansible/build/70a19ba23bee4f1fbade5848f79a9df9/) (when vexxhost provider is used).

The `ubuntu-bionic-2vcpu` label can not be used because it would use [nodes with 2Go memory](https://github.com/ansible-network/windmill-config/blob/a33d2fb004ca69cd56ecb1814ad63d6e82aeeefb/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml#L378) (vexxhost flavor:
`v2-highcpu-2`, used on region `sjc1`).
`ubuntu-bionic-4vcpu` will select nodes with at least 4Go:
- [vexxhost sjc1/v2-highcpu-4](https://github.com/ansible-network/windmill-config/blob/a33d2fb004ca69cd56ecb1814ad63d6e82aeeefb/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml#L384): 4Go
- [vexxhost ca-ymq-1/v3-standard-2](https://github.com/ansible-network/windmill-config/blob/a33d2fb004ca69cd56ecb1814ad63d6e82aeeefb/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml#L233): 8Go
- [limestone us-dfw-1/l1.large](https://github.com/ansible-network/windmill-config/blob/a33d2fb004ca69cd56ecb1814ad63d6e82aeeefb/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml#L511): 8Go
- [limestone us-slc/l1.large](https://github.com/ansible-network/windmill-config/blob/a33d2fb004ca69cd56ecb1814ad63d6e82aeeefb/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml#L651): 8Go

Fedora node with 4Go isn't defined within the nodepool configuration.