### PR TITLE
Testbox memory

### DIFF
--- a/tools/Vagrantfile
+++ b/tools/Vagrantfile
@@ -2,6 +2,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "generic/alpine310"
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider :libvirt do |l|
+    l.memory = 512
     l.nic_model_type = "e1000"
     l.driver = "qemu"
     l.cpu_mode = 'custom'

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -2,6 +2,11 @@
 set -euxo pipefail
 # Used by Zuul CI to perform extra bootstrapping
 
+sudo dd if=/dev/zero of=/swap.img bs=1024 count=1048576
+sudo chmod 600 /swap.img
+sudo mkswap /swap.img
+sudo swapon /swap.img
+
 # Platforms coverage:
 # Fedora 30 : has vagrant-libvirt no compilation needed
 # CentOS 7  : install upstream vagrant rpm and compiles plugin (broken runtime)


### PR DESCRIPTION
This patchset is trying to make testing with Zuul CI working again. The tests are failing
as they're running inside a VM with 1G and things like the VM used to create the test box
is asking 2048M, which fails.
Reducing things to 512M should make things working again but an extra swap file is also
added to help in case the memory pressure is still too much.