### PR TITLE
tox.ini: Molecule has renamed its master branch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ extras =
     test
 deps =
     py{36,37,38,39}: molecule[test]
-    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
+    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@main#egg=molecule[test]
 commands =
     pytest --collect-only
     # -s is added in order to allow live output on long running functional tests


### PR DESCRIPTION
The devel test suite is failing due to trying to use the 'master'
branch, which is now called 'main'. Update tox.ini accordingly.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>