### PR TITLE
Master rename

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,7 +6,7 @@ on:
       - "**"
   push:  # only publishes pushes to the main branch to TestPyPI
     branches:  # any integration branch but not tag
-      - "master"
+      - "main"
   pull_request:
   release:
     types:

--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ License
 
 The `MIT`_ License.
 
-.. _`MIT`: https://github.com/ansible/molecule/blob/master/LICENSE
+.. _`MIT`: https://github.com/ansible-community/molecule-vagrant/blob/main/LICENSE
 
 The logo is licensed under the `Creative Commons NoDerivatives 4.0 License`_.
 


### PR DESCRIPTION
Change some places still pointing to the master branch, which is now "main" for molecule and molecule-vagrant.
