### PR TITLE
Fix testing error due to invalid role name

### DIFF
--- a/molecule_vagrant/test/functional/test_func.py
+++ b/molecule_vagrant/test/functional/test_func.py
@@ -25,27 +25,21 @@ import os
 from molecule import util
 from molecule import logger
 from molecule.util import run_command
-from molecule.test.conftest import change_dir_to, molecule_directory
+from molecule.test.conftest import change_dir_to
 
 LOG = logger.get_logger(__name__)
 
 
 # @pytest.mark.xfail(reason="need to fix template path")
 def test_command_init_scenario(temp_dir):
-    role_directory = os.path.join(temp_dir.strpath, "test-init")
-    cmd = ["molecule", "init", "role", "test-init"]
-    result = run_command(cmd)
-    assert result.returncode == 0
-
-    with change_dir_to(role_directory):
-        scenario_directory = os.path.join(molecule_directory(), "test-scenario")
+    with change_dir_to(temp_dir):
+        os.makedirs(os.path.join(temp_dir, "molecule", "default"))
+        scenario_directory = os.path.join(temp_dir, "molecule", "test-scenario")
         cmd = [
             "molecule",
             "init",
             "scenario",
             "test-scenario",
-            "--role-name",
-            "test-init",
             "--driver-name",
             "vagrant",
         ]


### PR DESCRIPTION
The testing is failing due to ansible-lint complaining about meta/main.yml
and test role being 'test-init', so not matching any fqrn.
Instead of trying to fix the meta/main.yml, take inspiration from what
has been done for molecule-podman.

To keep changes minimal, the scenario name has been kept to 'test-scenario'.
This lead to molecule init scenario command complaining that there's no
'default' scenario, so create an empty 'molecule/default' scenario directory
to workaround that.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>