### PR TITLE
Fix several CI failures

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -19,7 +19,9 @@ jobs:
     name: ${{ matrix.tox_env }}
     # macos is the only gh action platform with support for vagrant/virtualbox
     # https://github.com/actions/virtual-environments/issues/433
-    runs-on: macos-latest
+    # Keep 10.15 for now as there's no vagrant in macosx-latest
+    # ref: https://github.com/actions/virtual-environments/issues/4060
+    runs-on: macos-10.15
     strategy:
       fail-fast: false
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 ---
+ci:
+  skip:
+    # https://github.com/pre-commit-ci/issues/issues/55
+    - ansible-lint
 default_language_version:
   python: python3
 minimum_pre_commit_version: "1.14.0"

--- a/molecule_vagrant/test/scenarios/molecule/network/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/network/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     provision: true
     interfaces:
       - network_name: private_network
-        type: dhcp
+        ip: 192.168.56.4
         auto_config: true
 provisioner:
   name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/verify.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/verify.yml
@@ -1,6 +1,8 @@
 ---
 - hosts: all
   gather_facts: true
+  gather_subset:
+    - network
   tasks:
   - name: Set interface dict name
     set_fact:

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/verify.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/verify.yml
@@ -4,11 +4,11 @@
   gather_subset:
     - network
   tasks:
-  - name: Set interface dict name
-    set_fact:
-      iface: "{{ ansible_default_ipv4.interface }}"
+    - name: Set interface dict name
+      set_fact:
+        iface: "{{ ansible_default_ipv4.interface }}"
 
-  - name: Check network card pci infos
-    assert:
-      that:
-        - "ansible_facts[iface].module == 'e1000'"
+    - name: Check network card pci infos
+      assert:
+        that:
+          - "ansible_facts[iface].module == 'e1000'"

--- a/tools/tox-py38/pre.yml
+++ b/tools/tox-py38/pre.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: Ensure python3.8 is present
+      become: true
+      package:
+        name: python38
+        state: present

--- a/tools/tox-py39/pre.yml
+++ b/tools/tox-py39/pre.yml
@@ -1,8 +1,8 @@
 ---
 - hosts: all
   tasks:
-    - name: Ensure python3.8 is present
+    - name: Ensure python3.9 is present
       become: true
       package:
-        name: python38
+        name: python
         state: present

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -4,7 +4,8 @@
 - job:
     name: molecule-vagrant-fedora
     description: Run py38 tox environment
-    parent: ansible-tox-py38
+    parent: tox-py38
+    pre-run: tools/tox-py38/pre.yml
     nodeset: fedora-latest-1vcpu
     attempts: 2
     vars:

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -3,13 +3,13 @@
 
 - job:
     name: molecule-vagrant-fedora
-    description: Run py38 tox environment
-    parent: tox-py38
-    pre-run: tools/tox-py38/pre.yml
+    description: Run py39 tox environment
+    parent: tox-py39
+    pre-run: tools/tox-py39/pre.yml
     nodeset: fedora-latest-1vcpu
     attempts: 2
     vars:
-      tox_envlist: py38
+      tox_envlist: py39
     timeout: 5400  # 1.5h
 
 # CentOS is unsupported due to:


### PR DESCRIPTION
Since https://github.com/ansible/ansible-zuul-jobs/commit/472249173a10a53e6924f4df772cd993bce439e4,
the ansible-tox-py38 job is relying on centos-8-stream and tries to
install python38-devel.
Here, we're using fedora in order to test molecule-vagrant with
distribution packages and libvirt. And trying to install python38-devel
is failing since there's no python38-devel.

While I'm going to create a branch in my fork of with fixes for centos-8-stream,
it's a pain to use since it needs the workaround for krb5 and a new
workaround for libssh. The real fix would be hashicorp to fix their broken
RPMs but looks like months (years?) and bug reports are not enough
to get them fix this.
The other possibility would have been to use fedora and py39 but there's
no ansible-tox-py39 ATM.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>