### PR TITLE
Drop ansible extra dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,13 +66,9 @@ install_requires =
     pyyaml >= 5.1, < 6
     Jinja2 >= 2.11.3
     selinux
+    python-vagrant
 
 [options.extras_require]
-# Used to document Ansible specific requirements, not plugin requirements, as
-# they can be installed in different environments.
-ansible =
-    ansible
-    python-vagrant
 test =
     molecule[test]
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,9 @@ description =
     Unit testing
 usedevelop = True
 extras =
-    ansible
     test
 deps =
+    ansible-core
     py{36,37,38,39}: molecule[test]
     py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@main#egg=molecule[test]
 commands =


### PR DESCRIPTION
Remove ansible extra as it was producing incompatibilities with
newer versions of ansible, which had different package names.

Out module will no longer list ansible as a dependency.
