### PR TITLE
Avoid custom callback during testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ setenv =
     ANSIBLE_RETRY_FILES_ENABLED=0
     ANSIBLE_GATHERING={env:ANSIBLE_GATHERING:explicit}
     ANSIBLE_VERBOSITY={env:ANSIBLE_VERBOSITY:0}
-    ANSIBLE_CALLBACK_WHITELIST={env:ANSIBLE_CALLBACK_WHITELIST:profile_tasks,timer}
     PIP_DISABLE_PIP_VERSION_CHECK=1
     PY_COLORS={env:PY_COLORS:1}
     # pip: Avoid 2020-01-01 warnings: https://github.com/pypa/pip/issues/6207


### PR DESCRIPTION
Newer env var name caused undesired runtime warnings, so we
avoid running with custom callbacks during testings.
