### PR TITLE
Require molecule >= 3.4.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ zip_safe = False
 
 # These are required in actual runtime:
 install_requires =
-    molecule >= 3.2.0a0
+    molecule >= 3.4.1
     pyyaml >= 5.1, < 6
     Jinja2 >= 2.11.3
     selinux


### PR DESCRIPTION
As of today the oldest version of molecule still supported is 3.4.1,
and we want to be sure this driver is no used with versions older
than this.

This is also fixing a serious bug that made pip use pre-release versions. We should never make use of pre-release versions inside dependencies.