### PR TITLE
Bump tox/pip used during testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-minversion = 3.9.0
+minversion = 3.24.4
 envlist =
     lint
     packaging
     py{36,37,38,39,310}
     py{36,37,38,39,310}-{devel}
 isolated_build = True
+requires =
+    pip >= 21.3.1
 
 [testenv]
 description =


### PR DESCRIPTION
This fixes py39 execution on Fedora where we needed a newer pip to perform editable installs.