### PR TITLE
tools/create_testbox.sh: Don't create test box if already available

### DIFF
--- a/tools/create_testbox.sh
+++ b/tools/create_testbox.sh
@@ -7,7 +7,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # we will use during testing.
 cd $DIR
 
-# sudo su: dirty hack to make sure that usermod change has been taken into account
+vagrant box list |grep -qw testbox && exit 0
+
+rm -f testbox.box
 vagrant up --no-tty --debug
 vagrant halt
 vagrant package --output testbox.box


### PR DESCRIPTION
With GHA caching the testbox may already be there so trying to add
a new testbox will fail, to exit early in this case.

Also make sure there's no testbox.box file in the current directory,
even if this should not happen in the CI theorically.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>