### PR TITLE
fix: Invalid Vagrant file generated when using vagrant-vmware-desktop

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -254,22 +254,22 @@ Vagrant.configure('2') do |config|
     ##
     # Provider
     ##
-    c.vm.provider "{{ instance.provider }}" do |{{ instance.provider | lower }}, override|
+    c.vm.provider "{{ instance.provider }}" do |{{ instance.name | lower }}, override|
       {% if instance.provider.startswith('vmware_') %}
-      {{ instance.provider | lower }}.vmx['memsize'] = {{ instance.memory }}
-      {{ instance.provider | lower }}.vmx['numvcpus'] = {{ instance.cpus }}
+      {{ instance.name | lower }}.vmx['memsize'] = {{ instance.memory }}
+      {{ instance.name| lower }}.vmx['numvcpus'] = {{ instance.cpus }}
       {% else %}
-      {{ instance.provider | lower }}.memory = {{ instance.memory }}
-      {{ instance.provider | lower }}.cpus = {{ instance.cpus }}
+      {{ instance.name | lower }}.memory = {{ instance.memory }}
+      {{ instance.name | lower }}.cpus = {{ instance.cpus }}
       {% endif %}
 
       {% for option, value in instance.provider_options.items() %}
-      {{ instance.provider | lower }}.{{ option }} = {{ ruby_format(value) }}
+      {{ instance.name | lower }}.{{ option }} = {{ ruby_format(value) }}
       {% endfor %}
 
       {% if instance.provider_raw_config_args is not none %}
         {% for arg in instance.provider_raw_config_args %}
-      {{ instance.provider | lower }}.{{ arg }}
+      {{ instance.name | lower }}.{{ arg }}
         {% endfor %}
       {% endif %}
 


### PR DESCRIPTION
in the vm.provider block. When molecule `provider.name == 'vagrant-vmware-desktop'`
Vagrant takes exception to the "-" in the iterator name, and the syntax check fails.
Some example configs to re-produce:
```
# molecule.yml
---
dependency:
  name: galaxy
driver:
  name: vagrant
  provider:
    name: vagrant-vmware-desktop
  provision: no
  cachier: machine
  parallel: true

platforms:
  - name: router
    interfaces:
      - network_name: private_network
        auto_config: true
      - network_name: public_network
        auto_config: true
    config_options:
      ssh.keep_alive: yes
      ssh.remote_user: 'vagrant'
      # synced_folder: true
    box: spox/ubuntu-arm
    box_version: 1.0.0
    memory: 1024
    cpus: 1
    provider_options:
      video_type: 'vga'
provisioner:
  name: ansible
  playbooks:
    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
```

This is the result of running `molecule create`
```
....
PLAY [Create] ******************************************************************

TASK [Create molecule instance(s)] *********************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to validate generated Vagrantfile: b'Vagrant failed to initialize at a very early stage:\\n\\nThere is a syntax error in the following Vagrantfile. The syntax error\\nmessage is reproduced below for convenience:\\n\\n/Users/myself/.cache/molecule/pidns/router/Vagrantfile:57: syntax error, unexpected \\'-\\', expecting \\'|\\'\\n...nt-vmware-desktop\" do |vagrant-vmware-desktop, override|\\n...                              ^\\n/Users/myself/.cache/molecule/pidns/router/Vagrantfile:57: syntax error, unexpected \\',\\', expecting `end\\'\\n...op\" do |vagrant-vmware-desktop, override|\\n...                              ^\\n/Users/myself/.cache/molecule/pidns/router/Vagrantfile:74: syntax error, unexpected `end\\', expecting end-of-input\\n  end\\n  ^~~\\n'"}

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
...
```

Running `vagrant validate` confirms the above, albeit in a slightly nicer format:
```
Vagrant failed to initialize at a very early stage:

There is a syntax error in the following Vagrantfile. The syntax error
message is reproduced below for convenience:

/Users/myself/.cache/molecule/pidns/router/Vagrantfile:57: syntax error, unexpected '-', expecting '|'
...nt-vmware-desktop" do |vagrant-vmware-desktop, override|
...                              ^
/Users/myself/.cache/molecule/pidns/router/Vagrantfile:57: syntax error, unexpected ',', expecting `end'
...op" do |vagrant-vmware-desktop, override|
...                              ^
/Users/myself/.cache/molecule/pidns/router/Vagrantfile:74: syntax error, unexpected `end', expecting end-of-input
  end
  ^~~
```

So lets look at line 57 in the generated `Vagrantfile`:
```
 57     c.vm.provider "vagrant-vmware-desktop" do |vagrant-vmware-desktop, override|
 58
 59       vagrant-vmware-desktop.memory = 1024
 60       vagrant-vmware-desktop.cpus = 1
```

On a hunch, I replaced the `-` with `_` to see if `vagrant validate` would be happy, it was, and more importantly, `vagrant up` resulted in the expected vm. Hurrah!

So on to the code itself. BTW Im by no means a python expert, so my "fix" may be a bit of a blunt instrument. Im happy to modify accordingly.

Some grepping led me to `modules/vagrant.py` and the `VAGRANT_TEMPLATE` variable. As you can see from the diff, I have utilised `instance.name` instead of `instance.provider` the logic being that the instance name is within the control of the user, however the plugin name is not. Perhaps a better solution would be to still use `instance.provider` and then `s/-/_/g'.

Rudimentary tests were successful in both vm creation and destruction.