### PR TITLE
Allow setting instance host name

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,15 +30,15 @@ jobs:
             platform: ubuntu-latest
             skip_vagrant: true
           - tox_env: py38,py38-devel
-            PREFIX: PYTEST_REQPASS=10
+            PREFIX: PYTEST_REQPASS=11
             platform: macos-10.15
             python_version: "3.8"
           - tox_env: py39,py39-devel
-            PREFIX: PYTEST_REQPASS=10
+            PREFIX: PYTEST_REQPASS=11
             platform: macos-10.15
             python_version: "3.9"
           - tox_env: py310,py310-devel
-            PREFIX: PYTEST_REQPASS=10
+            PREFIX: PYTEST_REQPASS=11
             platform: macos-10.15
             python_version: "3.10"
           - tox_env: packaging

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,10 @@ Here's a full example with the libvirt provider:
 
    platforms:
      - name: instance
+       # If specified, set host name to hostname, unless it's set to False and
+       # the host name won't be set. In all other cases (including default) use
+       # 'name' as host name.
+       hostname: foo.bar.com
        # List of dictionaries mapped to `config.vm.network`
        interfaces:
          # `network_name` is the required identifier, all other keys map to

--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -235,7 +235,13 @@ Vagrant.configure('2') do |config|
     {% if k not in ['synced_folder', 'cachier'] %}c.{{ k }} = {{ ruby_format(v) }}{% endif %}
     {% endfor %}
 
+    {% if instance.hostname is boolean and instance.hostname is sameas false %}
+    # c.vm.hostname not set
+    {% elif instance.hostname is string %}
+    c.vm.hostname = "{{ instance.hostname }}"
+    {% else %}
     c.vm.hostname = "{{ instance.name }}"
+    {% endif %}
 
     ##
     # Network
@@ -606,6 +612,7 @@ class VagrantClient(object):
             )
         d = {
             "name": instance.get("name"),
+            "hostname": instance.get("hostname", instance.get("name")),
             "memory": instance.get("memory", 512),
             "cpus": instance.get("cpus", 2),
             "networks": networks,

--- a/molecule_vagrant/test/functional/test_func.py
+++ b/molecule_vagrant/test/functional/test_func.py
@@ -88,6 +88,7 @@ def test_invalide_settings(temp_dir):
         ("default"),
         ("default-compat"),
         ("network"),
+        ("hostname"),
     ],
 )
 def test_vagrant_root(temp_dir, scenario):

--- a/molecule_vagrant/test/scenarios/molecule/hostname/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/hostname/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: sample task  # noqa 305
+      ansible.builtin.shell:
+        cmd: uname
+        warn: false
+      changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/hostname/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/hostname/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+platforms:
+  - name: instance-1
+    box: ${TESTBOX:-debian/jessie64}
+    memory: 256
+    cpus: 1
+  - name: instance-2
+    hostname: instance.example.com
+    box: ${TESTBOX:-debian/jessie64}
+    memory: 256
+    cpus: 1
+  - name: instance-3
+    hostname: false
+    box: ${TESTBOX:-debian/jessie64}
+    memory: 256
+    cpus: 1
+provisioner:
+  name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/hostname/verify.yml
+++ b/molecule_vagrant/test/scenarios/molecule/hostname/verify.yml
@@ -1,0 +1,33 @@
+---
+- name: Check instance-1
+  hosts: instance-1
+  gather_facts: true
+  gather_subset:
+    - min
+  tasks:
+    - name: Ensure that host name is instance-1
+      ansible.builtin.assert:
+        that:
+          - ansible_fqdn == "instance-1"
+
+- name: Check instance-2
+  hosts: instance-2
+  gather_facts: true
+  gather_subset:
+    - min
+  tasks:
+    - name: Ensure that host name is instance.example.com
+      ansible.builtin.assert:
+        that:
+          - ansible_fqdn == "instance.example.com"
+
+- name: Check instance-3
+  hosts: instance-3
+  gather_facts: true
+  gather_subset:
+    - min
+  tasks:
+    - name: Ensure that host name is not instance-3
+      ansible.builtin.assert:
+        that:
+          - ansible_fqdn != "instance-3"

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -48,9 +48,12 @@ sudo virt-host-validate qemu || true
 # Install Vagrant using their questionable practices, see locked ticket:
 # https://github.com/hashicorp/vagrant/issues/11070
 
+# 2.2.10 minimum otherwise setting config.vm.hostname won't work correctly with alpine boxes.
+VAGRANT_VERSION=2.2.19
+
 which vagrant || \
     sudo $PKG_CMD install -y vagrant-libvirt || {
-        sudo $PKG_CMD install -y https://releases.hashicorp.com/vagrant/2.2.10/vagrant_2.2.10_x86_64.rpm
+        sudo $PKG_CMD install -y https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.rpm
     }
 
 if [ -f /etc/os-release ]; then
@@ -61,8 +64,8 @@ if [ -f /etc/os-release ]; then
                 18.04)
                     # ubuntu xenial vagrant is too old so it doesn't support triggers, used by the alpine box
                     sudo apt-get remove --purge -y vagrant
-                    wget --no-show-progress https://releases.hashicorp.com/vagrant/2.2.9/vagrant_2.2.9_x86_64.deb
-                    sudo dpkg -i vagrant_2.2.9_x86_64.deb
+                    wget --no-show-progress https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb
+                    sudo dpkg -i vagrant_${VAGRANT_VERSION}_x86_64.deb
                     ;;
                 *)
                     ;;


### PR DESCRIPTION
It may be useful to be able to set the instance hostname/FQDN or to prevent
vagrant to set the hostname, so add support for that.

The default behaviour is unchanged: the host name is set to the instance
name.

Fixes: #157
Signed-off-by: Arnaud Patard <apatard@hupstream.com>