### PR TITLE
Add support for vagrant-vsphere memory and cpu

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -255,7 +255,10 @@ Vagrant.configure('2') do |config|
     # Provider
     ##
     c.vm.provider "{{ instance.provider }}" do |{{ instance.provider | lower }}, override|
-      {% if instance.provider.startswith('vmware_') %}
+      {% if instance.provider == "vsphere" %}
+      {{ instance.provider | lower }}.memory_mb = {{ instance.memory }}
+      {{ instance.provider | lower }}.cpu_count = {{ instance.cpus }}
+      {% elif instance.provider.startswith('vmware_') %}
       {{ instance.provider | lower }}.vmx['memsize'] = {{ instance.memory }}
       {{ instance.provider | lower }}.vmx['numvcpus'] = {{ instance.cpus }}
       {% else %}


### PR DESCRIPTION
vagrant-vsphere uses its own way of configuring memory and number of cpus. This needs to be reflected in the template for the Vagrantfile