### PR TITLE
Add validate() implementation

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,15 +30,15 @@ jobs:
             platform: ubuntu-latest
             skip_vagrant: true
           - tox_env: py38,py38-devel
-            PREFIX: PYTEST_REQPASS=9
+            PREFIX: PYTEST_REQPASS=10
             platform: macos-10.15
             python_version: "3.8"
           - tox_env: py39,py39-devel
-            PREFIX: PYTEST_REQPASS=9
+            PREFIX: PYTEST_REQPASS=10
             platform: macos-10.15
             python_version: "3.9"
           - tox_env: py310,py310-devel
-            PREFIX: PYTEST_REQPASS=9
+            PREFIX: PYTEST_REQPASS=10
             platform: macos-10.15
             python_version: "3.10"
           - tox_env: packaging

--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -559,15 +559,11 @@ class VagrantClient(object):
 
     def _write_configs(self):
         self._write_vagrantfile()
-        valid = subprocess.run(
-            ["vagrant", "validate"],
-            cwd=self._config["workdir"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        if valid.returncode != 0:
+        try:
+            self._vagrant.validate(self._config["workdir"])
+        except subprocess.CalledProcessError as e:
             self._module.fail_json(
-                msg="Failed to validate generated Vagrantfile: {}".format(valid.stderr)
+                msg=f"Failed to validate generated Vagrantfile: {e.stderr}"
             )
 
     def _get_vagrant(self):

--- a/molecule_vagrant/test/functional/test_func.py
+++ b/molecule_vagrant/test/functional/test_func.py
@@ -65,6 +65,20 @@ def test_command_init_scenario(temp_dir):
         assert result.returncode == 0
 
 
+def test_invalide_settings(temp_dir):
+
+    scenario_directory = os.path.join(
+        os.path.dirname(util.abs_path(__file__)), os.path.pardir, "scenarios"
+    )
+
+    with change_dir_to(scenario_directory):
+        cmd = ["molecule", "create", "--scenario-name", "invalid"]
+        result = run_command(cmd)
+        assert result.returncode == 2
+
+        assert "Failed to validate generated Vagrantfile" in result.stdout
+
+
 @pytest.mark.parametrize(
     "scenario",
     [

--- a/molecule_vagrant/test/scenarios/molecule/invalid/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/invalid/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: sample task  # noqa 305
+      ansible.builtin.shell:
+        cmd: uname
+        warn: false
+      changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/invalid/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/invalid/molecule.yml
@@ -1,0 +1,11 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+platforms:
+  - name: instance/foo
+provisioner:
+  name: ansible

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ install_requires =
     pyyaml >= 5.1
     Jinja2 >= 2.11.3
     selinux
-    python-vagrant
+    python-vagrant >= 1.0.0
 
 [options.extras_require]
 test =


### PR DESCRIPTION
python-vagrant 1.0.0 adds a new validate() function, so use it
instead of the open coded version here. [ So, bump minimal version
to 1.0.0 ].

While at it, add a small test case for it to make sure it's handled
properly as I managed to get it wrong in my first version of this
patch.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>