### PR TITLE
.github/workflows/tox.yml: Increase version of actions/checkout

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -53,7 +53,9 @@ jobs:
         if: ${{ ! matrix.skip_vagrant }}
 
       - name: Check out src from Git
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # needed by setuptools-scm
 
       - name: Enable vagrant box caching
         uses: actions/cache@v2


### PR DESCRIPTION
While having a look at https://github.com/ansible-community/molecule-podman/issues/1,
found issue https://github.com/ansible-community/molecule-podman/issues/97.

Given it's talking of possible security issue, bump to a newer version.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>