### PR TITLE
`driver.provider.name` Overrided by `VAGRANT_DEFAULT_PROVIDER`

### DIFF
--- a/molecule_vagrant/modules/vagrant.py
+++ b/molecule_vagrant/modules/vagrant.py
@@ -343,6 +343,7 @@ stderr:
 class VagrantClient(object):
     def __init__(self, module):
         self._module = module
+        self.provider = self._module.params["provider_name"]
         self.provision = self._module.params["provision"]
         self.cachier = self._module.params["cachier"]
 
@@ -434,9 +435,10 @@ class VagrantClient(object):
         changed = False
         if self._running() != len(self.instances):
             changed = True
+            provider = self.provider
             provision = self.provision
             try:
-                self._vagrant.up(provision=provision)
+                self._vagrant.up(provider=provider, provision=provision)
             except Exception:
                 # NOTE(retr0h): Ignore the exception since python-vagrant
                 # passes the actual error as a no-argument ContextManager.


### PR DESCRIPTION
In case environment variable `VAGRANT_DEFAULT_PROVIDER` is defined (see
<https://www.vagrantup.com/docs/other/environmental-variables#vagrant_default_provider>),
our `driver.provider.name` will have no effect and always start with
above default provider as specifiied.

With python-vagrant `up()` (see
<https://github.com/pycontribs/python-vagrant/blob/main/src/vagrant/__init__.py#L310-L318>)
we could specify the target provider with `provider` option, where our
current wrapper only provide the `provision` option.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>