### PR TITLE
create.yml: Fix ansible-lint 6.3.0 errors in task writing instances cfg

### DIFF
--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -22,7 +22,8 @@
 
     # Mandatory configuration for Molecule to function.
 
-    - when: server.changed | bool
+    - name: Create molecule instances configuration
+      when: server is changed  # noqa no-handler
       block:
 
         - name: Populate instance config dict

--- a/molecule_vagrant/test/scenarios/molecule/default-compat/create.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default-compat/create.yml
@@ -38,7 +38,8 @@
 
     # Mandatory configuration for Molecule to function.
 
-    - when: server.changed | bool
+    - name: Create molecule instances configuration
+      when: server is changed  # noqa no-handler
       block:
 
         - name: Populate instance config dict


### PR DESCRIPTION
Fixes the following errors:
- unnamed-task by adding a "name:" to the task
- no-handler: I'm not sure it's really interesting to convert
  it to an handler so just silence the warning.

There's still a schema error but it's will be fixed by ansible-lint
schema update [ https://github.com/ansible/schemas/commit/795989e7950c7412e184e2aae93dcf33710544d4 ].

Signed-off-by: Arnaud Patard <apatard@hupstream.com>