### PR TITLE
Allow to force vagrant provider in vagrant up

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,15 +32,15 @@ jobs:
             platform: ubuntu-latest
             skip_vagrant: true
           - tox_env: py38,py38-devel
-            PREFIX: PYTEST_REQPASS=11
+            PREFIX: PYTEST_REQPASS=12
             platform: macos-12
             python_version: "3.8"
           - tox_env: py39,py39-devel
-            PREFIX: PYTEST_REQPASS=11
+            PREFIX: PYTEST_REQPASS=12
             platform: macos-12
             python_version: "3.9"
           - tox_env: py310,py310-devel
-            PREFIX: PYTEST_REQPASS=11
+            PREFIX: PYTEST_REQPASS=12
             platform: macos-12
             python_version: "3.10"
           - tox_env: packaging

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,8 @@ Here's a full example with the libvirt provider:
        # Can be any supported provider (virtualbox, parallels, libvirt, etc)
        # Defaults to virtualbox
        name: libvirt
+     # Run vagrant up with --provider
+     force_provider: false
      # Run vagrant up with --provision.
      # Defaults to --no-provision)
      provision: no

--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -10,6 +10,7 @@
         instances: "{{ molecule_yml.platforms }}"
         default_box: "{{ molecule_yml.driver.default_box | default('generic/alpine310') }}"
         provider_name: "{{ molecule_yml.driver.provider.name | default(omit, true) }}"
+        provider_force: "{{ molecule_yml.driver.force_provider | default(omit) }}"
         provision: "{{ molecule_yml.driver.provision | default(omit) }}"
         cachier: "{{ molecule_yml.driver.cachier | default(omit) }}"
         parallel: "{{ molecule_yml.driver.parallel | default(omit) }}"

--- a/molecule_vagrant/test/functional/test_func.py
+++ b/molecule_vagrant/test/functional/test_func.py
@@ -79,6 +79,20 @@ def test_invalide_settings(temp_dir):
         assert "Failed to validate generated Vagrantfile" in result.stdout
 
 
+def test_provider_force(temp_dir):
+
+    scenario_directory = os.path.join(
+        os.path.dirname(util.abs_path(__file__)), os.path.pardir, "scenarios"
+    )
+
+    with change_dir_to(scenario_directory):
+        cmd = ["molecule", "create", "--scenario-name", "provider_force"]
+        result = run_command(cmd)
+        assert result.returncode == 2
+
+        assert "The provider 'vmware' could not be found" in result.stdout
+
+
 @pytest.mark.parametrize(
     "scenario",
     [

--- a/molecule_vagrant/test/scenarios/molecule/provider_force/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_force/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Sample task  # noqa command-instead-of-shell
+      ansible.builtin.shell:
+        cmd: uname
+        warn: false
+      changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/provider_force/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_force/molecule.yml
@@ -1,0 +1,12 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: vmware
+  force_provider: true
+platforms:
+  - name: instance
+provisioner:
+  name: ansible


### PR DESCRIPTION
Currently, vagrant is still choosing the provider to use on its own
liking. While it's fine for cases like our CI or people who are fine
with default VM configurations, it's not always the case.

See:
- https://github.com/ansible-community/molecule-vagrant/pull/174
- https://github.com/ansible-community/molecule-plugins/issues/66

So, add a new configuration setting to call vagrant up with
--provider, in order to force the provider to use and lead to an
error if it's not usable. The default value is to keep current
behaviour to not break things.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>