### PR TITLE
Enhance and fix provider handling

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,11 +32,11 @@ jobs:
             platform: ubuntu-latest
             skip_vagrant: true
           - tox_env: py39,py39-devel
-            PREFIX: PYTEST_REQPASS=11
+            PREFIX: PYTEST_REQPASS=12
             platform: macos-12
             python_version: "3.9"
           - tox_env: py310,py310-devel
-            PREFIX: PYTEST_REQPASS=11
+            PREFIX: PYTEST_REQPASS=12
             platform: macos-12
             python_version: "3.10"
           - tox_env: packaging

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,11 +32,11 @@ jobs:
             platform: ubuntu-latest
             skip_vagrant: true
           - tox_env: py39,py39-devel
-            PREFIX: PYTEST_REQPASS=12
+            PREFIX: PYTEST_REQPASS=13
             platform: macos-12
             python_version: "3.9"
           - tox_env: py310,py310-devel
-            PREFIX: PYTEST_REQPASS=12
+            PREFIX: PYTEST_REQPASS=13
             platform: macos-12
             python_version: "3.10"
           - tox_env: packaging

--- a/molecule_vagrant/test/functional/test_func.py
+++ b/molecule_vagrant/test/functional/test_func.py
@@ -85,6 +85,7 @@ def test_invalide_settings(temp_dir):
         ("vagrant_root"),
         ("config_options"),
         ("provider_config_options"),
+        ("provider_config_options2"),
         ("default"),
         ("default-compat"),
         ("network"),

--- a/molecule_vagrant/test/functional/test_func.py
+++ b/molecule_vagrant/test/functional/test_func.py
@@ -78,18 +78,25 @@ def test_command_init_scenario(temp_dir):
         assert result.returncode == 0
 
 
-def test_invalide_settings(temp_dir):
+@pytest.mark.parametrize(
+    "scenario,check",
+    [
+        ("invalid", "Failed to validate generated Vagrantfile"),
+        ("invalid_provider", "The provider 'vmware' could not be found"),
+    ],
+)
+def test_invalide_settings(temp_dir, scenario, check):
 
     scenario_directory = os.path.join(
         os.path.dirname(util.abs_path(__file__)), os.path.pardir, "scenarios"
     )
 
     with change_dir_to(scenario_directory):
-        cmd = ["molecule", "create", "--scenario-name", "invalid"]
+        cmd = ["molecule", "create", "--scenario-name", scenario]
         result = run_command(cmd)
         assert result.returncode == 2
 
-        assert "Failed to validate generated Vagrantfile" in result.stdout
+        assert check in result.stdout
 
 
 def patch_molecule(molecule_yaml):

--- a/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_options/molecule.yml
@@ -3,8 +3,6 @@ dependency:
   name: galaxy
 driver:
   name: vagrant
-  provider:
-    name: libvirt
 platforms:
   - name: instance
     config_options:

--- a/molecule_vagrant/test/scenarios/molecule/default-compat/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default-compat/molecule.yml
@@ -3,8 +3,6 @@ dependency:
   name: galaxy
 driver:
   name: vagrant
-  provider:
-    name: libvirt
 platforms:
   - name: instance
 provisioner:

--- a/molecule_vagrant/test/scenarios/molecule/default/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default/molecule.yml
@@ -3,8 +3,6 @@ dependency:
   name: galaxy
 driver:
   name: vagrant
-  provider:
-    name: libvirt
 platforms:
   - name: instance
 provisioner:

--- a/molecule_vagrant/test/scenarios/molecule/hostname/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/hostname/molecule.yml
@@ -3,22 +3,29 @@ dependency:
   name: galaxy
 driver:
   name: vagrant
-  provider:
-    name: libvirt
 platforms:
   - name: instance-1
     box: ${TESTBOX:-debian/jessie64}
     memory: 256
     cpus: 1
+    providers_options:
+      virtualbox: {}
+      libvirt: {}
   - name: instance-2
     hostname: instance.example.com
     box: ${TESTBOX:-debian/jessie64}
     memory: 256
     cpus: 1
+    providers_options:
+      virtualbox: {}
+      libvirt: {}
   - name: instance-3
     hostname: false
     box: ${TESTBOX:-debian/jessie64}
     memory: 256
     cpus: 1
+    providers_options:
+      virtualbox: {}
+      libvirt: {}
 provisioner:
   name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/invalid/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/invalid/molecule.yml
@@ -3,8 +3,6 @@ dependency:
   name: galaxy
 driver:
   name: vagrant
-  provider:
-    name: libvirt
 platforms:
   - name: instance/foo
 provisioner:

--- a/molecule_vagrant/test/scenarios/molecule/invalid_provider/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/invalid_provider/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Sample task  # noqa command-instead-of-shell
+      ansible.builtin.shell:
+        cmd: uname
+      changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/invalid_provider/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/invalid_provider/molecule.yml
@@ -1,0 +1,12 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: vmware
+  force_provider: true
+platforms:
+  - name: instance
+provisioner:
+  name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/multi-node/molecule.yml
@@ -3,22 +3,22 @@ dependency:
   name: galaxy
 driver:
   name: vagrant
-  provider:
-    name: libvirt
 platforms:
   - name: instance-1
     box: ${TESTBOX:-debian/jessie64}
     interfaces:
       - network_name: private_network
         ip: 192.168.56.2
+        auto_config: true
     groups:
       - foo
       - bar
     memory: 256
     cpus: 1
-    provider_options:
-      # using session with network leads to troubles
-      qemu_use_session: false
+    providers_options:
+      libvirt:
+        # using session with network leads to troubles
+        qemu_use_session: false
     config_options:
       synced_folder: true
     instance_raw_config_args:
@@ -28,14 +28,16 @@ platforms:
     interfaces:
       - network_name: private_network
         ip: 192.168.56.3
+        auto_config: true
     groups:
       - foo
       - baz
     memory: 256
     cpus: 2
-    provider_options:
-      # using session with network leads to troubles
-      qemu_use_session: false
+    providers_options:
+      libvirt:
+        # using session with network leads to troubles
+        qemu_use_session: false
     instance_raw_config_args:
       - 'vm.synced_folder ".", "/vagrant", type: "rsync"'
 provisioner:

--- a/molecule_vagrant/test/scenarios/molecule/network/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/network/molecule.yml
@@ -3,14 +3,13 @@ dependency:
   name: galaxy
 driver:
   name: vagrant
-  provider:
-    name: libvirt
 platforms:
   - name: instance
     box: ${TESTBOX:-centos/7}
-    provider_options:
-      # using session with network leads to troubles
-      qemu_use_session: false
+    providers_options:
+      libvirt:
+        # using session with network leads to troubles
+        qemu_use_session: false
     interfaces:
       - network_name: private_network
         ip: 192.168.56.4

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/molecule.yml
@@ -4,11 +4,11 @@ dependency:
 driver:
   name: vagrant
   provider:
-    name: libvirt
+    name: virtualbox
 platforms:
   - name: instance
     provider_options:
-      nic_model_type: e1000
+      default_nic_type: "82545EM"
     box: ${TESTBOX:-centos/7}
 provisioner:
   name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options2/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options2/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Sample task  # noqa command-instead-of-shell
+      ansible.builtin.shell:
+        cmd: uname
+      changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options2/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options2/molecule.yml
@@ -1,0 +1,18 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+platforms:
+  - name: instance
+    providers_options:
+      virtualbox:
+        default_nic_type: 82545EM
+      libvirt:
+        nic_model_type: e1000
+        qemu_use_session: false
+    box: ${TESTBOX:-centos/7}
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options2/verify.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options2/verify.yml
@@ -1,0 +1,15 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+  gather_subset:
+    - network
+  tasks:
+    - name: Set interface dict name
+      ansible.builtin.set_fact:
+        iface: "{{ ansible_default_ipv4.interface }}"
+
+    - name: Check network card pci infos
+      ansible.builtin.assert:
+        that:
+          - "ansible_facts[iface].module == 'e1000'"

--- a/molecule_vagrant/test/scenarios/molecule/vagrant_root/molecule.yml
+++ b/molecule_vagrant/test/scenarios/molecule/vagrant_root/molecule.yml
@@ -3,8 +3,6 @@ dependency:
   name: galaxy
 driver:
   name: vagrant
-  provider:
-    name: libvirt
   provision: true
 platforms:
   - name: instance


### PR DESCRIPTION
Current CI scenario are not handling nicely providers (or is using clever tricks) and current behaviour of vagrant choosing by itself the provider to use lead to troubles. This PR tries to address this. This could have been several PR but it made sens to me that it should be done in one PR.
I've made sure that after each commit the testsuite was still fine with vbox and libvirt (tested with py39 tox env).