### PR TITLE
Silence ansible fqcn error about vagrant module.

### DIFF
--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -5,7 +5,7 @@
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
   tasks:
-    - name: Create molecule instance(s)
+    - name: Create molecule instance(s)  # noqa fqcn[action]
       vagrant:
         instances: "{{ molecule_yml.platforms }}"
         default_box: "{{ molecule_yml.driver.default_box | default('generic/alpine310') }}"

--- a/molecule_vagrant/playbooks/destroy.yml
+++ b/molecule_vagrant/playbooks/destroy.yml
@@ -5,7 +5,7 @@
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
   tasks:
-    - name: Destroy molecule instance(s)
+    - name: Destroy molecule instance(s)  # noqa fqcn[action]
       vagrant:
         instances: "{{ molecule_yml.platforms }}"
         default_box: "{{ molecule_yml.driver.default_box | default('generic/alpine310') }}"

--- a/molecule_vagrant/test/scenarios/molecule/default-compat/create.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default-compat/create.yml
@@ -5,7 +5,7 @@
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
   tasks:
-    - name: Create molecule instance(s)
+    - name: Create molecule instance(s)  # noqa fqcn[action]
       vagrant:
         instance_name: "{{ item.name }}"
         instance_interfaces: "{{ item.interfaces | default(omit) }}"

--- a/molecule_vagrant/test/scenarios/molecule/default-compat/destroy.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default-compat/destroy.yml
@@ -5,7 +5,7 @@
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
   tasks:
-    - name: Destroy molecule instance(s)
+    - name: Destroy molecule instance(s)  # noqa fqcn[action]
       vagrant:
         instance_name: "{{ item.name }}"
         platform_box: "{{ item.box | default(omit) }}"


### PR DESCRIPTION
The local vagrant module is not (yet?) inside a collection, so there's no FQCN. Add needed noqa bits.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>