### PR TITLE
use alpine316

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,8 +86,8 @@ Here's a full example with the libvirt provider:
      # Defaults to true
      parallel: true
      # vagrant box to use by default
-     # Defaults to 'generic/alpine310'
-     default_box: 'generic/alpine310'
+     # Defaults to 'generic/alpine316'
+     default_box: 'generic/alpine316'
 
    platforms:
      - name: instance

--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -8,7 +8,7 @@
     - name: Create molecule instance(s)
       vagrant:
         instances: "{{ molecule_yml.platforms }}"
-        default_box: "{{ molecule_yml.driver.default_box | default('generic/alpine310') }}"
+        default_box: "{{ molecule_yml.driver.default_box | default('generic/alpine316') }}"
         provider_name: "{{ molecule_yml.driver.provider.name | default(omit, true) }}"
         provision: "{{ molecule_yml.driver.provision | default(omit) }}"
         cachier: "{{ molecule_yml.driver.cachier | default(omit) }}"

--- a/molecule_vagrant/playbooks/destroy.yml
+++ b/molecule_vagrant/playbooks/destroy.yml
@@ -8,7 +8,7 @@
     - name: Destroy molecule instance(s)
       vagrant:
         instances: "{{ molecule_yml.platforms }}"
-        default_box: "{{ molecule_yml.driver.default_box | default('generic/alpine310') }}"
+        default_box: "{{ molecule_yml.driver.default_box | default('generic/alpine316') }}"
         provider_name: "{{ molecule_yml.driver.provider.name | default(omit, true) }}"
         cachier: "{{ molecule_yml.driver.cachier | default(omit) }}"
         force_stop: "{{ item.force_stop | default(true) }}"

--- a/molecule_vagrant/test/scenarios/molecule/default-compat/create.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default-compat/create.yml
@@ -13,7 +13,7 @@
 
         config_options: "{{ item.config_options | default(omit) }}"
 
-        platform_box: "{{ item.box | default('generic/alpine310') }}"
+        platform_box: "{{ item.box | default('generic/alpine316') }}"
         platform_box_version: "{{ item.box_version | default(omit) }}"
         platform_box_url: "{{ item.box_url | default(omit) }}"
 

--- a/tools/Vagrantfile
+++ b/tools/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/alpine310"
+  config.vm.box = "generic/alpine316"
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider :libvirt do |l|
     l.memory = 512

--- a/tools/create_testbox.sh
+++ b/tools/create_testbox.sh
@@ -5,9 +5,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Used to test that Vagrant is usable and also to pre-download the image
 # we will use during testing.
-cd $DIR
+cd "${DIR}"
 
-vagrant box list |grep -qw testbox && exit 0
+vagrant box list | grep -qw testbox && exit 0
 
 rm -f testbox.box
 vagrant up --no-tty --debug

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -5,8 +5,8 @@ set -euxo pipefail
 sudo dd if=/dev/zero of=/swap.img bs=1024 count=1048576
 sudo chmod 600 /swap.img
 sudo losetup -f /swap.img
-sudo mkswap $(sudo losetup --associated /swap.img|sed 's,:.*,,')
-sudo swapon $(sudo losetup --associated /swap.img|sed 's,:.*,,')
+sudo mkswap "$(sudo losetup --associated /swap.img|sed 's,:.*,,')"
+sudo swapon "$(sudo losetup --associated /swap.img|sed 's,:.*,,')"
 
 # Platforms coverage:
 # Fedora 30 : has vagrant-libvirt no compilation needed
@@ -22,7 +22,7 @@ command -v python3 python
 PYTHON=$(command -v python3 python|head -n1)
 PKG_CMD=$(command -v dnf yum apt-get|head -n1)
 
-sudo $PYTHON -m pip install -U tox
+sudo "${PYTHON}" -m pip install -U tox
 
 # === LIBVIRT SETUP ===
 sudo systemctl enable --now libvirtd
@@ -52,8 +52,8 @@ sudo virt-host-validate qemu || true
 VAGRANT_VERSION=2.2.19
 
 which vagrant || \
-    sudo $PKG_CMD install -y vagrant-libvirt || {
-        sudo $PKG_CMD install -y https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.rpm
+    sudo "${PKG_CMD}" install -y vagrant-libvirt || {
+        sudo "${PKG_CMD}" install -y "https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.rpm"
     }
 
 if [ -f /etc/os-release ]; then
@@ -75,7 +75,7 @@ if [ -f /etc/os-release ]; then
             case "$VERSION_ID" in
                 31)
                     # https://bugzilla.redhat.com/show_bug.cgi?id=1839651
-                    sudo $PKG_CMD upgrade -y --enablerepo=updates-testing --advisory=FEDORA-2020-09c472786c
+                    sudo "${PKG_CMD}" upgrade -y --enablerepo=updates-testing --advisory=FEDORA-2020-09c472786c
                     ;;
                 *)
                     ;;
@@ -85,7 +85,7 @@ if [ -f /etc/os-release ]; then
             # https://github.com/hashicorp/vagrant/issues/11020
             if grep -qi '^CentOS Linux release 8.2.*' /etc/centos-release ; then
                 # https://bugs.centos.org/view.php?id=17120
-                relver="$(cat /etc/centos-release | awk '{print $4}')"
+                relver="$(grep -v '^#' /etc/centos-release | awk '{print $4}')"
                 sudo sed -i /etc/yum.repos.d/CentOS-Sources.repo -e 's,$contentdir/,,g'
                 sudo sed -i /etc/yum.repos.d/CentOS-Sources.repo -e "s,\$releasever,$relver,g"
 
@@ -130,7 +130,7 @@ vagrant plugin list | grep vagrant-libvirt || {
 
 if [ -f /etc/debian_version ]; then
     dpkg -l | grep libselinux
-    [ -x /usr/bin/aa-enabled ] && echo "Apparmor: `/usr/bin/aa-enabled`"
+    [ -x /usr/bin/aa-enabled ] && echo "Apparmor: $(/usr/bin/aa-enabled)"
 else
     rpm -qa | grep libselinux
 fi


### PR DESCRIPTION
This PR:
- replaces the `generic/alpine310` box with `generic/alpine316`, this because Alpine 3.10 has been EOL since 2021-05-01
- performs some basic shell linting