### PR TITLE
remove warn from shell and command tasks

### DIFF
--- a/molecule_vagrant/test/scenarios/molecule/config_options/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/config_options/converge.yml
@@ -7,5 +7,4 @@
     - name: Sample task  # noqa command-instead-of-shell
       ansible.builtin.shell:
         cmd: uname
-        warn: false
       changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/default-compat/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default-compat/converge.yml
@@ -7,5 +7,4 @@
     - name: Sample task  # noqa command-instead-of-shell
       ansible.builtin.command:
         cmd: uname
-        warn: false
       changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/default/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default/converge.yml
@@ -7,5 +7,4 @@
     - name: Sample task  # noqa command-instead-of-shell
       ansible.builtin.shell:
         cmd: uname
-        warn: false
       changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/hostname/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/hostname/converge.yml
@@ -7,5 +7,4 @@
     - name: Sample task  # noqa command-instead-of-shell
       ansible.builtin.shell:
         cmd: uname
-        warn: false
       changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/invalid/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/invalid/converge.yml
@@ -7,5 +7,4 @@
     - name: Sample task  # noqa command-instead-of-shell
       ansible.builtin.shell:
         cmd: uname
-        warn: false
       changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/multi-node/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/multi-node/converge.yml
@@ -7,5 +7,4 @@
     - name: Sample task  # noqa command-instead-of-shell
       ansible.builtin.shell:
         cmd: uname
-        warn: false
       changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/multi-node/verify.yml
+++ b/molecule_vagrant/test/scenarios/molecule/multi-node/verify.yml
@@ -7,7 +7,6 @@
     - name: Ping instance-2  # noqa command-instead-of-shell
       ansible.builtin.shell:
         cmd: ping -c3 192.168.56.3
-        warn: false
       changed_when: false
 
 - name: Change instance-2
@@ -18,5 +17,4 @@
     - name: Ping instance-1  # noqa command-instead-of-shell
       ansible.builtin.shell:
         cmd: ping -c3 192.168.56.2
-        warn: false
       changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/network/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/network/converge.yml
@@ -7,5 +7,4 @@
     - name: Sample task  # noqa command-instead-of-shell
       ansible.builtin.shell:
         cmd: uname
-        warn: false
       changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/provider_config_options/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/provider_config_options/converge.yml
@@ -7,5 +7,4 @@
     - name: Sample task  # noqa command-instead-of-shell
       ansible.builtin.shell:
         cmd: uname
-        warn: false
       changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/vagrant_root/converge.yml
+++ b/molecule_vagrant/test/scenarios/molecule/vagrant_root/converge.yml
@@ -7,5 +7,4 @@
     - name: Sample task  # noqa command-instead-of-shell
       ansible.builtin.shell:
         cmd: uname
-        warn: false
       changed_when: false

--- a/molecule_vagrant/test/scenarios/molecule/vagrant_root/verify.yml
+++ b/molecule_vagrant/test/scenarios/molecule/vagrant_root/verify.yml
@@ -13,7 +13,8 @@
           - workdir.stat.exists | bool
 
     - name: Get /tmp/workdir file content
-      ansible.builtin.command: cat /tmp/workdir
+      ansible.builtin.command:
+        cmd: cat /tmp/workdir
       changed_when: false
       register: workdir_content
 


### PR DESCRIPTION
This PR:
- removes `warn:` from `command:` and `shell:` tasks, the feature is deprecated for `command:` (https://docs.ansible.com/ansible/latest/collections/ansible/builtin/command_module.html#parameter-warn)

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>