### PR TITLE
Re-post: use generic/alpine316

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,8 +86,8 @@ Here's a full example with the libvirt provider:
      # Defaults to true
      parallel: true
      # vagrant box to use by default
-     # Defaults to 'generic/alpine310'
-     default_box: 'generic/alpine310'
+     # Defaults to 'generic/alpine316'
+     default_box: 'generic/alpine316'
 
    platforms:
      - name: instance

--- a/molecule_vagrant/playbooks/create.yml
+++ b/molecule_vagrant/playbooks/create.yml
@@ -8,7 +8,7 @@
     - name: Create molecule instance(s)
       vagrant:
         instances: "{{ molecule_yml.platforms }}"
-        default_box: "{{ molecule_yml.driver.default_box | default('generic/alpine310') }}"
+        default_box: "{{ molecule_yml.driver.default_box | default('generic/alpine316') }}"
         provider_name: "{{ molecule_yml.driver.provider.name | default(omit, true) }}"
         provision: "{{ molecule_yml.driver.provision | default(omit) }}"
         cachier: "{{ molecule_yml.driver.cachier | default(omit) }}"

--- a/molecule_vagrant/playbooks/destroy.yml
+++ b/molecule_vagrant/playbooks/destroy.yml
@@ -8,7 +8,7 @@
     - name: Destroy molecule instance(s)
       vagrant:
         instances: "{{ molecule_yml.platforms }}"
-        default_box: "{{ molecule_yml.driver.default_box | default('generic/alpine310') }}"
+        default_box: "{{ molecule_yml.driver.default_box | default('generic/alpine316') }}"
         provider_name: "{{ molecule_yml.driver.provider.name | default(omit, true) }}"
         cachier: "{{ molecule_yml.driver.cachier | default(omit) }}"
         force_stop: "{{ item.force_stop | default(true) }}"

--- a/molecule_vagrant/test/scenarios/molecule/default-compat/create.yml
+++ b/molecule_vagrant/test/scenarios/molecule/default-compat/create.yml
@@ -13,7 +13,7 @@
 
         config_options: "{{ item.config_options | default(omit) }}"
 
-        platform_box: "{{ item.box | default('generic/alpine310') }}"
+        platform_box: "{{ item.box | default('generic/alpine316') }}"
         platform_box_version: "{{ item.box_version | default(omit) }}"
         platform_box_url: "{{ item.box_url | default(omit) }}"
 

--- a/tools/Vagrantfile
+++ b/tools/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/alpine310"
+  config.vm.box = "generic/alpine316"
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.provider :libvirt do |l|
     l.memory = 512


### PR DESCRIPTION
This PR:
- replaces the generic/alpine310 box with generic/alpine316, this because Alpine 3.10 has been EOL since 2021-05-01

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>