### PR TITLE
Update build-system requirements for setuptools-scm to >= 7.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [build-system]
 requires = [
-  "setuptools >= 42.0.0",  # required by pyproject+setuptools_scm integration
-  "setuptools_scm[toml] >= 3.5.0",  # required for "no-local-version" scheme
-  "setuptools_scm_git_archive >= 1.0",
-  "wheel",
+  "setuptools >= 45.0.0",  # required by pyproject+setuptools_scm integration
+  "setuptools_scm[toml] >= 7.0.0",  # required for "no-local-version" scheme
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
pyproject.toml:
Update build-system requirements for setuptools-scm to >= 7.0.0, which obsoletes setuptools-scm-git-archive.
Remove wheel, as it is not required in a PEP517 build environment facilitating pypa/build and pypa/installer.