### PR TITLE
Update GH actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Switch to using Python 3.8 by default
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install tox
@@ -28,7 +28,7 @@ jobs:
         --user
         tox
     - name: Check out src from Git
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0  # needed by setuptools-scm
     - name: Build dists

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
     - name: Switch to using Python 3.8 by default
       uses: actions/setup-python@v4
+      cache: 'pip'
       with:
         python-version: 3.8
     - name: Install tox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
     - name: Switch to using Python 3.8 by default
       uses: actions/setup-python@v4
-      cache: 'pip'
       with:
+        cache: 'pip'
         python-version: 3.8
     - name: Install tox
       run: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
     - name: Switch to using Python 3.8 by default
       uses: actions/setup-python@v4
       with:
-        cache: 'pip'
         python-version: 3.8
     - name: Install tox
       run: >-

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -68,14 +68,17 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('tools/Vagrantfile') }}
 
       - name: Install a default Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v2
+        with:
+          cache: pip
 
       # Be sure to install the version of python needed by a specific test, if necessary
       - name: Set up Python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v2
         if: ${{ matrix.python_version }}
         with:
           python-version: ${{ matrix.python_version }}
+          cache: pip
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -69,14 +69,15 @@ jobs:
 
       - name: Install a default Python
         uses: actions/setup-python@v4
-        cache: 'pip'
+        with:
+          cache: 'pip'
 
       # Be sure to install the version of python needed by a specific test, if necessary
       - name: Set up Python version
         uses: actions/setup-python@v4
-        cache: 'pip'
         if: ${{ matrix.python_version }}
         with:
+          cache: 'pip'
           python-version: ${{ matrix.python_version }}
 
       - name: Install dependencies

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -69,10 +69,12 @@ jobs:
 
       - name: Install a default Python
         uses: actions/setup-python@v4
+        cache: 'pip'
 
       # Be sure to install the version of python needed by a specific test, if necessary
       - name: Set up Python version
         uses: actions/setup-python@v4
+        cache: 'pip'
         if: ${{ matrix.python_version }}
         with:
           python-version: ${{ matrix.python_version }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -69,15 +69,12 @@ jobs:
 
       - name: Install a default Python
         uses: actions/setup-python@v4
-        with:
-          cache: 'pip'
 
       # Be sure to install the version of python needed by a specific test, if necessary
       - name: Set up Python version
         uses: actions/setup-python@v4
         if: ${{ matrix.python_version }}
         with:
-          cache: 'pip'
           python-version: ${{ matrix.python_version }}
 
       - name: Install dependencies

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -55,12 +55,12 @@ jobs:
         if: ${{ ! matrix.skip_vagrant }}
 
       - name: Check out src from Git
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # needed by setuptools-scm
 
       - name: Enable vagrant box caching
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: ${{ ! matrix.skip_vagrant }}
         with:
           path: |
@@ -68,11 +68,11 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('tools/Vagrantfile') }}
 
       - name: Install a default Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       # Be sure to install the version of python needed by a specific test, if necessary
       - name: Set up Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         if: ${{ matrix.python_version }}
         with:
           python-version: ${{ matrix.python_version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+molecule >= 3.4.1
+pyyaml >= 5.1
+Jinja2 >= 2.11.3
+selinux
+python-vagrant >= 1.0.0


### PR DESCRIPTION
This PR:
- Updates the GitHub actions, since Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>