### PR TITLE
Update GH actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,9 @@ jobs:
 
     steps:
     - name: Switch to using Python 3.8 by default
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
+        cache: pip
         python-version: 3.8
     - name: Install tox
       run: >-
@@ -28,7 +29,7 @@ jobs:
         --user
         tox
     - name: Check out src from Git
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0  # needed by setuptools-scm
     - name: Build dists

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -67,17 +67,11 @@ jobs:
             ~/.vagrant.d/boxes
           key: ${{ runner.os }}-${{ hashFiles('tools/Vagrantfile') }}
 
-      - name: Install a default Python
-        uses: actions/setup-python@v4
-        with:
-          cache: pip
-
       # Be sure to install the version of python needed by a specific test, if necessary
       - name: Set up Python version
         uses: actions/setup-python@v2
-        if: ${{ matrix.python_version }}
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: ${{ matrix.python_version || '3.8' }}
           cache: pip
 
       - name: Install dependencies

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -55,12 +55,12 @@ jobs:
         if: ${{ ! matrix.skip_vagrant }}
 
       - name: Check out src from Git
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # needed by setuptools-scm
 
       - name: Enable vagrant box caching
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: ${{ ! matrix.skip_vagrant }}
         with:
           path: |
@@ -68,7 +68,9 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('tools/Vagrantfile') }}
 
       - name: Install a default Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          cache: pip
 
       # Be sure to install the version of python needed by a specific test, if necessary
       - name: Set up Python version
@@ -76,6 +78,7 @@ jobs:
         if: ${{ matrix.python_version }}
         with:
           python-version: ${{ matrix.python_version }}
+          cache: pip
 
       - name: Install dependencies
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+molecule >= 3.4.1
+pyyaml >= 5.1
+Jinja2 >= 2.11.3
+selinux
+python-vagrant >= 1.0.0


### PR DESCRIPTION
This PR:
- Updates the GitHub actions, since Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
- Closes #200 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>